### PR TITLE
#5 회고 룸 엔티티 생성

### DIFF
--- a/src/main/java/choorai/retrospect/retrospect_room/entity/RetrospectRoom.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/entity/RetrospectRoom.java
@@ -1,0 +1,35 @@
+package choorai.retrospect.retrospect_room.entity;
+
+import choorai.retrospect.global.domain.BaseEntity;
+import choorai.retrospect.retrospect_room.entity.value.Details;
+import choorai.retrospect.retrospect_room.entity.value.ShareLink;
+import choorai.retrospect.retrospect_room.entity.value.Subject;
+import choorai.retrospect.retrospect_room.entity.value.Type;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.sql.Time;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class RetrospectRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private Subject subject;
+
+    @Embedded
+    private Details details;
+
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+    private Time timeLimit;
+
+    @Embedded
+    private ShareLink shareLink;
+}

--- a/src/main/java/choorai/retrospect/retrospect_room/entity/value/Details.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/entity/value/Details.java
@@ -1,0 +1,31 @@
+package choorai.retrospect.retrospect_room.entity.value;
+
+import choorai.retrospect.retrospect_room.excpetion.RetrospectRoomErrorCode;
+import choorai.retrospect.retrospect_room.excpetion.RetrospectRoomException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Embeddable
+public class Details {
+
+    private static final int DETAILS_MAX_LENGTH = 500;
+
+    @Column(name = "details", columnDefinition = "TEXT")
+    private String value;
+
+    public Details(final String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(final String value) throws RetrospectRoomException {
+        if (value.length() > DETAILS_MAX_LENGTH) {
+            throw new RetrospectRoomException(RetrospectRoomErrorCode.DETAILS_LENGTH_ERROR);
+        }
+    }
+}

--- a/src/main/java/choorai/retrospect/retrospect_room/entity/value/ShareLink.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/entity/value/ShareLink.java
@@ -1,0 +1,31 @@
+package choorai.retrospect.retrospect_room.entity.value;
+
+import choorai.retrospect.retrospect_room.excpetion.RetrospectRoomErrorCode;
+import choorai.retrospect.retrospect_room.excpetion.RetrospectRoomException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Embeddable
+public class ShareLink {
+
+    private static final int SHARE_LINK_MAX_LENGTH = 200;
+
+    @Column(name = "share_link")
+    private String value;
+
+    public ShareLink(final String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(final String value) {
+        if (value.length() > SHARE_LINK_MAX_LENGTH) {
+            throw new RetrospectRoomException(RetrospectRoomErrorCode.SHARE_LINK_ERROR);
+        }
+    }
+}

--- a/src/main/java/choorai/retrospect/retrospect_room/entity/value/Subject.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/entity/value/Subject.java
@@ -1,0 +1,31 @@
+package choorai.retrospect.retrospect_room.entity.value;
+
+import choorai.retrospect.retrospect_room.excpetion.RetrospectRoomErrorCode;
+import choorai.retrospect.retrospect_room.excpetion.RetrospectRoomException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Embeddable
+public class Subject {
+
+    private static final int SUBJECT_MAX_LENGTH = 100;
+
+    @Column(name = "subject")
+    private String value;
+
+    public Subject(final String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(final String value) {
+        if (value.length() > SUBJECT_MAX_LENGTH) {
+            throw new RetrospectRoomException(RetrospectRoomErrorCode.SUBJECT_LENGTH_ERROR);
+        }
+    }
+}

--- a/src/main/java/choorai/retrospect/retrospect_room/entity/value/Type.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/entity/value/Type.java
@@ -1,0 +1,6 @@
+package choorai.retrospect.retrospect_room.entity.value;
+
+public enum Type {
+
+    KPT;
+}

--- a/src/main/java/choorai/retrospect/retrospect_room/excpetion/RetrospectRoomErrorCode.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/excpetion/RetrospectRoomErrorCode.java
@@ -1,0 +1,37 @@
+package choorai.retrospect.retrospect_room.excpetion;
+
+import choorai.retrospect.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum RetrospectRoomErrorCode implements ErrorCode {
+
+    // TODO : errorCode는 추후 회의를 통해 숫자로 변경
+    SUBJECT_LENGTH_ERROR(HttpStatus.BAD_REQUEST, "잘못된 입력", "회고 주제의 글자 길이는 200자를 넘길 수 없습니다."),
+    DETAILS_LENGTH_ERROR(HttpStatus.BAD_REQUEST, "잘못된 입력", "회고 상세 내용은 500자 미만이어야 합니다."),
+    SHARE_LINK_ERROR(HttpStatus.BAD_REQUEST, "잘못된 입력", "공유 링크 크기는 200자를 넘길 수 없습니다");
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String errorMessage;
+
+    RetrospectRoomErrorCode(HttpStatus httpStatus, String errorCode, String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/choorai/retrospect/retrospect_room/excpetion/RetrospectRoomException.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/excpetion/RetrospectRoomException.java
@@ -1,0 +1,17 @@
+package choorai.retrospect.retrospect_room.excpetion;
+
+import choorai.retrospect.global.exception.CommonException;
+import choorai.retrospect.global.exception.ErrorCode;
+
+import java.util.Map;
+
+public class RetrospectRoomException extends CommonException {
+
+    public RetrospectRoomException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public RetrospectRoomException(ErrorCode errorCode, Map<String, Object> additionalInfo) {
+        super(errorCode, additionalInfo);
+    }
+}

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -1,0 +1,11 @@
+CREATE TABLE if NOT EXISTS retrospect_room
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    subject    VARCHAR(255),
+    details    TEXT,
+    type       ENUM('KPT'),
+    time_limit TIME,
+    share_link VARCHAR(255),
+    created_at datetime(6),
+    updated_at datetime(6)
+);

--- a/src/test/java/choorai/retrospect/retrospect_room/DetailsTest.java
+++ b/src/test/java/choorai/retrospect/retrospect_room/DetailsTest.java
@@ -1,0 +1,24 @@
+package choorai.retrospect.retrospect_room;
+
+import choorai.retrospect.retrospect_room.entity.value.Details;
+import choorai.retrospect.retrospect_room.excpetion.RetrospectRoomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static choorai.retrospect.retrospect_room.excpetion.RetrospectRoomErrorCode.DETAILS_LENGTH_ERROR;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DetailsTest {
+
+    @DisplayName("회고 상세 내용 글자 수가 500자를 넘기면 예외를 발생한다.")
+    @Test
+    void return_error_with_wrong_value() {
+        // given
+        String value = "글".repeat(501);
+        // when
+        // then
+        assertThatThrownBy(() -> new Details(value))
+            .isInstanceOf(RetrospectRoomException.class)
+            .hasMessage(DETAILS_LENGTH_ERROR.getMessage());
+    }
+}

--- a/src/test/java/choorai/retrospect/retrospect_room/ShareLinkTest.java
+++ b/src/test/java/choorai/retrospect/retrospect_room/ShareLinkTest.java
@@ -1,0 +1,24 @@
+package choorai.retrospect.retrospect_room;
+
+import choorai.retrospect.retrospect_room.entity.value.ShareLink;
+import choorai.retrospect.retrospect_room.excpetion.RetrospectRoomException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static choorai.retrospect.retrospect_room.excpetion.RetrospectRoomErrorCode.SHARE_LINK_ERROR;
+
+class ShareLinkTest {
+
+    @DisplayName("공유링크의 길이가 200자를 넘기면 예외를 발생한다.")
+    @Test
+    void return_error_with_wrong_value() {
+        // given
+        String value = "글".repeat(201);
+        // when
+        // then
+        Assertions.assertThatThrownBy(() -> new ShareLink(value))
+            .isInstanceOf(RetrospectRoomException.class)
+            .hasMessage(SHARE_LINK_ERROR.getMessage());
+    }
+}

--- a/src/test/java/choorai/retrospect/retrospect_room/SubjectTest.java
+++ b/src/test/java/choorai/retrospect/retrospect_room/SubjectTest.java
@@ -1,0 +1,24 @@
+package choorai.retrospect.retrospect_room;
+
+import choorai.retrospect.retrospect_room.entity.value.Subject;
+import choorai.retrospect.retrospect_room.excpetion.RetrospectRoomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static choorai.retrospect.retrospect_room.excpetion.RetrospectRoomErrorCode.SUBJECT_LENGTH_ERROR;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SubjectTest {
+
+    @DisplayName("회고 주제 글자 수가 100자 넘으면 예외를 발생한다.")
+    @Test
+    void return_error_with_wrong_value() {
+        // given
+        String value = "글".repeat(101);
+        // when
+        // then
+        assertThatThrownBy(() -> new Subject(value))
+            .isInstanceOf(RetrospectRoomException.class)
+            .hasMessage(SUBJECT_LENGTH_ERROR.getMessage());
+    }
+}


### PR DESCRIPTION
## 회고 룸 내 필드 정보
- id
- subject(회고 주제)
- details (회고 상세 내용)
- type (회고 종류)
- time_limit (회고 진행 시간)
- share_link (회고 공유링크)

## 회고 룸 엔티티를 만드면서 고민한 점
현재 회고 룸 안에 share link(회고 공유 링크)를 담고 있는데 share link를 저장할 것이라면 share link도 하나의 테이블로 관리해야할 것 같다는 생각이 들었습니다. 그 이유는 share link가 유효 여부를 db로 관리해서 참가 요청이 들어왔는데 참가가 가능한지 아닌지를 파악해야할 것 같습니다.

- close #5 