### PR TITLE
RH-8 : BaseEntity 추가

### DIFF
--- a/src/main/java/choorai/retrospect/global/domain/BaseEntity.java
+++ b/src/main/java/choorai/retrospect/global/domain/BaseEntity.java
@@ -1,0 +1,21 @@
+package choorai.retrospect.global.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/choorai/retrospect/global/domain/BaseEntity.java
+++ b/src/main/java/choorai/retrospect/global/domain/BaseEntity.java
@@ -1,5 +1,6 @@
 package choorai.retrospect.global.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class BaseEntity {
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate


### PR DESCRIPTION
### 내용
- 객체의 "생성시간" "수정시간"을 관리할 수 있는 BaseEntity를 생성하였습니다.
- JPA의 auditing 기능을 활용할 수 있도록 `@EntityListeners(AuditingEntityListener.class)`를 추가하였고
- 각 Entity들이 상속받을 수 있도록, `@MappedSuperclass`를 추가하였습니다.

### 더 말하고 싶은 부분
- 테스트코드의 경우엔, 실제로 BaseEntity를 상속받는 특정 객체의 소관?이라는 생각이 들어서 구현하지 않았습니다!
- 실제로 TestEntity를 생성해서 구현을 해보자니.. 레포지토리도 생성하는 등 추가되는 클래스가 좀 있었는데, 현재 많은 사람들이 잘사용하고 있는 JPA Auditing 기능을 테스트하기 위해 관련 클래스를 3개~정도 생성해야한다는게 이해가 잘 안되어서 구현하지 않은 것도 있습니다