### PR TITLE
RH-13 : 로그인 api 구현 (w. JWT)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/choorai/retrospect/auth/JwtAuthFilter.java
+++ b/src/main/java/choorai/retrospect/auth/JwtAuthFilter.java
@@ -1,0 +1,72 @@
+package choorai.retrospect.auth;
+
+import choorai.retrospect.auth.service.JwtService;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class JwtAuthFilter implements Filter {
+
+    private final JwtService jwtService;
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        Filter.super.init(filterConfig);
+    }
+
+    @Override
+    public void destroy() {
+        Filter.super.destroy();
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+        throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+        HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
+
+        String requestURI = httpRequest.getRequestURI();
+        if (requestURI.startsWith("/auth/")) {
+            filterChain.doFilter(servletRequest, servletResponse);
+            return;
+        }
+
+        String authHeader = httpRequest.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            try {
+                if (jwtService.validateToken(token)) {
+                    String userEmail = jwtService.extractUserEmail(token);
+                    httpRequest.setAttribute("userEmail", userEmail);
+                } else {
+                    httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "JWT가 유효하지 않습니다.");
+                    return;
+                }
+            } catch (JwtException e) {
+                httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "JWT 검증 작업 중 예외가 발생했습니다.");
+                return;
+            }
+        } else {
+            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증을 위한 헤더가 존재하지 않습니다.");
+            return;
+        }
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+}

--- a/src/main/java/choorai/retrospect/auth/entity/RefreshToken.java
+++ b/src/main/java/choorai/retrospect/auth/entity/RefreshToken.java
@@ -1,0 +1,40 @@
+package choorai.retrospect.auth.entity;
+
+import choorai.retrospect.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.Date;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private Date expiryDate;
+
+    public RefreshToken(String token, User user, Date expiryDate) {
+        this.token = token;
+        this.user = user;
+        this.expiryDate = expiryDate;
+    }
+}

--- a/src/main/java/choorai/retrospect/auth/entity/dto/LoginRequest.java
+++ b/src/main/java/choorai/retrospect/auth/entity/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package choorai.retrospect.auth.entity.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class LoginRequest {
+
+    String email;
+
+    String password;
+
+}

--- a/src/main/java/choorai/retrospect/auth/entity/dto/LoginResponse.java
+++ b/src/main/java/choorai/retrospect/auth/entity/dto/LoginResponse.java
@@ -1,5 +1,8 @@
 package choorai.retrospect.auth.entity.dto;
 
+import lombok.Getter;
+
+@Getter
 public class LoginResponse {
 
     private String accessToken;

--- a/src/main/java/choorai/retrospect/auth/entity/dto/LoginResponse.java
+++ b/src/main/java/choorai/retrospect/auth/entity/dto/LoginResponse.java
@@ -1,0 +1,13 @@
+package choorai.retrospect.auth.entity.dto;
+
+public class LoginResponse {
+
+    private String accessToken;
+    private String refreshToken;
+
+    public LoginResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+}

--- a/src/main/java/choorai/retrospect/auth/entity/dto/LogoutRequest.java
+++ b/src/main/java/choorai/retrospect/auth/entity/dto/LogoutRequest.java
@@ -1,0 +1,14 @@
+package choorai.retrospect.auth.entity.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class LogoutRequest {
+
+    String refreshToken;
+
+}

--- a/src/main/java/choorai/retrospect/auth/entity/dto/ReissueTokenRequest.java
+++ b/src/main/java/choorai/retrospect/auth/entity/dto/ReissueTokenRequest.java
@@ -1,0 +1,14 @@
+package choorai.retrospect.auth.entity.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReissueTokenRequest {
+
+    String refreshToken;
+
+}

--- a/src/main/java/choorai/retrospect/auth/entity/dto/ReissueTokenResponse.java
+++ b/src/main/java/choorai/retrospect/auth/entity/dto/ReissueTokenResponse.java
@@ -1,0 +1,13 @@
+package choorai.retrospect.auth.entity.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ReissueTokenResponse {
+
+    private String accessToken;
+
+    public ReissueTokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/choorai/retrospect/auth/entity/repository/RefreshTokenRepository.java
+++ b/src/main/java/choorai/retrospect/auth/entity/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package choorai.retrospect.auth.entity.repository;
+
+import choorai.retrospect.auth.entity.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+    
+    void deleteByToken(String token);
+}

--- a/src/main/java/choorai/retrospect/auth/exception/AuthErrorCode.java
+++ b/src/main/java/choorai/retrospect/auth/exception/AuthErrorCode.java
@@ -1,0 +1,38 @@
+package choorai.retrospect.auth.exception;
+
+import choorai.retrospect.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum AuthErrorCode implements ErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "잘못된 입력", "아이디 또는 비밀번호가 잘못됐습니다."),
+    WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "잘못된 입력", "아이디 또는 비밀번호가 잘못됐습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST,"잘못된 입력", "refresh token이 유효하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "잘못된 입력", "refresh token이 존재하지 않습니다."),
+    REFRESH_TOKEN_IS_EXPIRED(HttpStatus.BAD_REQUEST, "잘못된 입력", "refresh token이 만료되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String errorMessage;
+
+    AuthErrorCode(HttpStatus httpStatus, String errorCode, String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return this.errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.errorMessage;
+    }
+}

--- a/src/main/java/choorai/retrospect/auth/exception/AuthException.java
+++ b/src/main/java/choorai/retrospect/auth/exception/AuthException.java
@@ -1,0 +1,17 @@
+package choorai.retrospect.auth.exception;
+
+import choorai.retrospect.global.exception.CommonException;
+import choorai.retrospect.global.exception.ErrorCode;
+import java.util.Map;
+
+public class AuthException extends CommonException {
+
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuthException(ErrorCode errorCode,
+                         Map<String, Object> additionalInfo) {
+        super(errorCode, additionalInfo);
+    }
+}

--- a/src/main/java/choorai/retrospect/auth/service/AuthService.java
+++ b/src/main/java/choorai/retrospect/auth/service/AuthService.java
@@ -1,0 +1,70 @@
+package choorai.retrospect.auth.service;
+
+import choorai.retrospect.auth.entity.RefreshToken;
+import choorai.retrospect.auth.entity.repository.RefreshTokenRepository;
+import choorai.retrospect.auth.exception.AuthErrorCode;
+import choorai.retrospect.auth.exception.AuthException;
+import choorai.retrospect.user.entity.User;
+import choorai.retrospect.auth.entity.dto.LoginRequest;
+import choorai.retrospect.auth.entity.dto.LoginResponse;
+import choorai.retrospect.auth.entity.dto.RefreshTokenResponse;
+import choorai.retrospect.user.entity.repository.UserRepository;
+import choorai.retrospect.user.entity.value.Email;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final JwtService jwtService;
+
+
+    public LoginResponse login(LoginRequest request) {
+        final User findUser = getUser(request);
+        if (!findUser.getPassword().isEqual(request.getPassword())) {
+            throw new AuthException(AuthErrorCode.WRONG_PASSWORD);
+        }
+        final String accessToken = jwtService.generateAccessToken(request.getEmail());
+        final String refreshToken = jwtService.generateRefreshToken(request.getEmail());
+        saveRefreshToken(refreshToken, findUser);
+        return new LoginResponse(accessToken, refreshToken);
+    }
+
+    public RefreshTokenResponse refreshAccessToken(String refreshTokenValue) {
+        if (!jwtService.validateToken(refreshTokenValue)) {
+            throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+        final RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
+            .orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+        if (refreshToken.getExpiryDate().before(new Date())) {
+            refreshTokenRepository.delete(refreshToken);
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_IS_EXPIRED);
+        }
+
+        final String userEmail = jwtService.extractUserEmail(refreshTokenValue);
+        final String newAccessToken = jwtService.generateAccessToken(userEmail);
+        return new RefreshTokenResponse(newAccessToken);
+    }
+
+    public void logout(String refreshTokenValue) {
+        refreshTokenRepository.deleteByToken(refreshTokenValue);
+    }
+
+    private void saveRefreshToken(String refreshTokenValue, User user) {
+        Date expiryDate = jwtService.extractExpiration(refreshTokenValue);
+        RefreshToken refreshToken = new RefreshToken(refreshTokenValue, user, expiryDate);
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    private User getUser(LoginRequest request) {
+        final Email inputEmail = new Email(request.getEmail());
+        return userRepository.findByEmail(inputEmail)
+            .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/choorai/retrospect/auth/service/AuthService.java
+++ b/src/main/java/choorai/retrospect/auth/service/AuthService.java
@@ -7,9 +7,10 @@ import choorai.retrospect.auth.exception.AuthException;
 import choorai.retrospect.user.entity.User;
 import choorai.retrospect.auth.entity.dto.LoginRequest;
 import choorai.retrospect.auth.entity.dto.LoginResponse;
-import choorai.retrospect.auth.entity.dto.RefreshTokenResponse;
+import choorai.retrospect.auth.entity.dto.ReissueTokenResponse;
 import choorai.retrospect.user.entity.repository.UserRepository;
 import choorai.retrospect.user.entity.value.Email;
+import jakarta.transaction.Transactional;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ public class AuthService {
     private final JwtService jwtService;
 
 
+    @Transactional
     public LoginResponse login(LoginRequest request) {
         final User findUser = getUser(request);
         if (!findUser.getPassword().isEqual(request.getPassword())) {
@@ -36,7 +38,8 @@ public class AuthService {
         return new LoginResponse(accessToken, refreshToken);
     }
 
-    public RefreshTokenResponse refreshAccessToken(String refreshTokenValue) {
+    @Transactional
+    public ReissueTokenResponse reissueAccessToken(String refreshTokenValue) {
         if (!jwtService.validateToken(refreshTokenValue)) {
             throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
@@ -49,9 +52,10 @@ public class AuthService {
 
         final String userEmail = jwtService.extractUserEmail(refreshTokenValue);
         final String newAccessToken = jwtService.generateAccessToken(userEmail);
-        return new RefreshTokenResponse(newAccessToken);
+        return new ReissueTokenResponse(newAccessToken);
     }
 
+    @Transactional
     public void logout(String refreshTokenValue) {
         refreshTokenRepository.deleteByToken(refreshTokenValue);
     }

--- a/src/main/java/choorai/retrospect/auth/service/JwtService.java
+++ b/src/main/java/choorai/retrospect/auth/service/JwtService.java
@@ -1,0 +1,76 @@
+package choorai.retrospect.auth.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtService {
+
+    private final long ACCESS_TOKEN_VALIDITY = 1000 * 60 * 15; // 15분
+    private final long REFRESH_TOKEN_VALIDITY = 1000 * 60 * 60 * 24 * 7; // 7일
+
+    private final Key secretKey;
+
+
+    public JwtService(@Value("${jwt.secret.key}") String secret) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(String userEmail) {
+        return generateToken(userEmail, ACCESS_TOKEN_VALIDITY);
+    }
+
+    public String generateRefreshToken(String userEmail) {
+        return generateToken(userEmail, REFRESH_TOKEN_VALIDITY);
+    }
+
+    private String generateToken(String userEmail, long validity) {
+        Date now = new Date();
+        return Jwts.builder()
+            .signWith(secretKey, SignatureAlgorithm.HS256)
+            .setSubject(userEmail)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + validity))
+            .compact();
+    }
+
+    public String extractUserEmail(String accessToken) {
+        final Claims claims = Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(accessToken)
+            .getBody();
+        return claims.getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            final Claims claims = getClaims(token);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+
+    public Date extractExpiration(String token) {
+        final Claims claims = getClaims(token);
+        return claims.getExpiration();
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+    }
+
+}

--- a/src/main/java/choorai/retrospect/auth/ui/AuthController.java
+++ b/src/main/java/choorai/retrospect/auth/ui/AuthController.java
@@ -1,0 +1,46 @@
+package choorai.retrospect.auth.ui;
+
+import choorai.retrospect.auth.entity.dto.LoginRequest;
+import choorai.retrospect.auth.entity.dto.LoginResponse;
+import choorai.retrospect.auth.entity.dto.LogoutRequest;
+import choorai.retrospect.auth.entity.dto.RefreshTokenRequest;
+import choorai.retrospect.auth.entity.dto.RefreshTokenResponse;
+import choorai.retrospect.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService userService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody final LoginRequest request) {
+        final LoginResponse loginResponse = userService.login(request);
+        return ResponseEntity.ok()
+            .body(loginResponse);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<RefreshTokenResponse> refresh(@RequestBody final RefreshTokenRequest request) {
+        String refreshToken = request.getRefreshToken();
+        final RefreshTokenResponse refreshTokenResponse = userService.refreshAccessToken(refreshToken);
+        return ResponseEntity.ok()
+            .body(refreshTokenResponse);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(@RequestBody final LogoutRequest request) {
+        final String refreshToken = request.getRefreshToken();
+        userService.logout(refreshToken);
+        return ResponseEntity.ok()
+            .body("LOGOUT SUCCESS");
+    }
+
+}

--- a/src/main/java/choorai/retrospect/auth/ui/AuthController.java
+++ b/src/main/java/choorai/retrospect/auth/ui/AuthController.java
@@ -3,8 +3,8 @@ package choorai.retrospect.auth.ui;
 import choorai.retrospect.auth.entity.dto.LoginRequest;
 import choorai.retrospect.auth.entity.dto.LoginResponse;
 import choorai.retrospect.auth.entity.dto.LogoutRequest;
-import choorai.retrospect.auth.entity.dto.RefreshTokenRequest;
-import choorai.retrospect.auth.entity.dto.RefreshTokenResponse;
+import choorai.retrospect.auth.entity.dto.ReissueTokenRequest;
+import choorai.retrospect.auth.entity.dto.ReissueTokenResponse;
 import choorai.retrospect.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,12 +27,12 @@ public class AuthController {
             .body(loginResponse);
     }
 
-    @PostMapping("/refresh")
-    public ResponseEntity<RefreshTokenResponse> refresh(@RequestBody final RefreshTokenRequest request) {
+    @PostMapping("/reissue")
+    public ResponseEntity<ReissueTokenResponse> reissue(@RequestBody final ReissueTokenRequest request) {
         String refreshToken = request.getRefreshToken();
-        final RefreshTokenResponse refreshTokenResponse = userService.refreshAccessToken(refreshToken);
+        final ReissueTokenResponse reissueTokenResponse = userService.reissueAccessToken(refreshToken);
         return ResponseEntity.ok()
-            .body(refreshTokenResponse);
+            .body(reissueTokenResponse);
     }
 
     @PostMapping("/logout")

--- a/src/main/java/choorai/retrospect/config/security/SecurityConfiguration.java
+++ b/src/main/java/choorai/retrospect/config/security/SecurityConfiguration.java
@@ -1,21 +1,28 @@
 package choorai.retrospect.config.security;
 
 
+import choorai.retrospect.auth.JwtAuthFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
 import java.util.List;
 
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
 
+@RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
 public class SecurityConfiguration {
+
+    private final JwtAuthFilter jwtAuthFilter;
 
     @Bean
     @Order(1)
@@ -31,6 +38,20 @@ public class SecurityConfiguration {
 
     @Bean
     @Order(2)
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(AbstractHttpConfigurer::disable)
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)  // JWT 필터 추가
+            .formLogin(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> {
+                auth.requestMatchers(antMatcher("/auth/**")).permitAll();
+                auth.anyRequest().authenticated();
+            })
+            .build();
+    }
+
+    @Bean
+    @Order(3)
     public SecurityFilterChain corsFilterChain(HttpSecurity http) throws Exception {
         return http
             .cors(corsConfig -> {

--- a/src/main/java/choorai/retrospect/user/entity/repository/UserRepository.java
+++ b/src/main/java/choorai/retrospect/user/entity/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package choorai.retrospect.user.entity.repository;
+
+import choorai.retrospect.user.entity.User;
+import choorai.retrospect.user.entity.value.Email;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(Email email);
+
+}

--- a/src/main/java/choorai/retrospect/user/entity/value/Email.java
+++ b/src/main/java/choorai/retrospect/user/entity/value/Email.java
@@ -49,4 +49,17 @@ public class Email {
             throw new UserException(UserErrorCode.EMAIL_FORM_ERROR);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Email email = (Email) o;
+        return value.equals(email.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
 }

--- a/src/main/java/choorai/retrospect/user/entity/value/Password.java
+++ b/src/main/java/choorai/retrospect/user/entity/value/Password.java
@@ -37,4 +37,8 @@ public class Password {
         }
     }
 
+    public boolean isEqual(String value) {
+        return this.value.equals(value);
+    }
+
 }

--- a/src/main/java/choorai/retrospect/user/exception/UserErrorCode.java
+++ b/src/main/java/choorai/retrospect/user/exception/UserErrorCode.java
@@ -14,9 +14,8 @@ public enum UserErrorCode implements ErrorCode {
     PASSWORD_LENGTH_ERROR(HttpStatus.BAD_REQUEST, "잘못된 입력",
                       String.format("비밀번호는 %d ~ %d 바이트 사이여야 합니다.", Password.MIN_LENGTH, Password.MAX_LENGTH)),
     NAME_LENGTH_ERROR(HttpStatus.BAD_REQUEST, "잘못된 입력",
-                      String.format("이름은 %d ~ %d 바이트 사이여야 합니다.", Name.MIN_LENGTH, Name.MAX_LENGTH)),
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "잘못된 입력", "아이디 또는 비밀번호가 잘못됐습니다."),
-    WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "잘못된 입력", "아이디 또는 비밀번호가 잘못됐습니다.");
+                      String.format("이름은 %d ~ %d 바이트 사이여야 합니다.", Name.MIN_LENGTH, Name.MAX_LENGTH));
+
     private final HttpStatus httpStatus;
     private final String errorCode;
     private final String errorMessage;

--- a/src/main/java/choorai/retrospect/user/exception/UserErrorCode.java
+++ b/src/main/java/choorai/retrospect/user/exception/UserErrorCode.java
@@ -14,7 +14,9 @@ public enum UserErrorCode implements ErrorCode {
     PASSWORD_LENGTH_ERROR(HttpStatus.BAD_REQUEST, "잘못된 입력",
                       String.format("비밀번호는 %d ~ %d 바이트 사이여야 합니다.", Password.MIN_LENGTH, Password.MAX_LENGTH)),
     NAME_LENGTH_ERROR(HttpStatus.BAD_REQUEST, "잘못된 입력",
-                      String.format("이름은 %d ~ %d 바이트 사이여야 합니다.", Name.MIN_LENGTH, Name.MAX_LENGTH));
+                      String.format("이름은 %d ~ %d 바이트 사이여야 합니다.", Name.MIN_LENGTH, Name.MAX_LENGTH)),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "잘못된 입력", "아이디 또는 비밀번호가 잘못됐습니다."),
+    WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "잘못된 입력", "아이디 또는 비밀번호가 잘못됐습니다.");
     private final HttpStatus httpStatus;
     private final String errorCode;
     private final String errorMessage;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -31,3 +31,7 @@ management:
     web:
       exposure:
         include: health
+
+jwt:
+  secret:
+    key: xQGtzPG4EUTcS5VYdGfxIBwveetugGz2

--- a/src/test/java/choorai/retrospect/auth/service/AuthServiceTest.java
+++ b/src/test/java/choorai/retrospect/auth/service/AuthServiceTest.java
@@ -1,23 +1,33 @@
 package choorai.retrospect.auth.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
-import choorai.retrospect.user.entity.User;
+import choorai.retrospect.auth.entity.RefreshToken;
 import choorai.retrospect.auth.entity.dto.LoginRequest;
 import choorai.retrospect.auth.entity.dto.LoginResponse;
+import choorai.retrospect.auth.entity.dto.ReissueTokenResponse;
+import choorai.retrospect.auth.entity.repository.RefreshTokenRepository;
+import choorai.retrospect.auth.exception.AuthErrorCode;
+import choorai.retrospect.auth.exception.AuthException;
+import choorai.retrospect.user.entity.User;
 import choorai.retrospect.user.entity.repository.UserRepository;
 import choorai.retrospect.user.entity.value.Email;
-import choorai.retrospect.user.exception.UserErrorCode;
-import choorai.retrospect.user.exception.UserException;
+import java.util.Date;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,24 +36,25 @@ class AuthServiceTest {
     @Mock
     UserRepository userRepository;
 
+    @Mock
+    RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    JwtService jwtService;
+
     @InjectMocks
     AuthService authService;
 
-    @Test
-    @DisplayName(value = "존재하는 이메일과 올바른 비밀번호를 입력하면 로그인에 성공한다.")
-    void successTest() {
-        // given
-        final User user = new User("alswn12345@gmail.com", "alswn12345", "정민주");
-        final LoginRequest loginRequest = new LoginRequest();
-        loginRequest.setEmail("alswn12345@gmail.com");
-        loginRequest.setPassword("alswn12345");
-        // when
-        when(userRepository.findByEmail(eq(new Email(loginRequest.getEmail()))))
-            .thenReturn(Optional.of(user));
-        final LoginResponse loginResponse = authService.login(loginRequest);
-        // then
-        assertNotNull(loginResponse);
+    private User user;
+    private RefreshToken refreshToken;
+
+    @BeforeEach
+    void setUp() {
+        user = new User("alswn12345@gmail.com", "alswn12345", "정민주");
+        refreshToken = new RefreshToken("refreshTokenValue", user,
+                                        new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24 * 7));
     }
+
 
     @Test
     @DisplayName(value = "존재하지 않은 이메일을 입력하면 예외가 발생한다.")
@@ -57,8 +68,8 @@ class AuthServiceTest {
             .thenReturn(Optional.empty());
         // then
         assertThatThrownBy(() -> authService.login(loginRequest))
-            .isInstanceOf(UserException.class)
-            .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+            .isInstanceOf(AuthException.class)
+            .hasMessage(AuthErrorCode.USER_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -74,8 +85,93 @@ class AuthServiceTest {
             .thenReturn(Optional.of(user));
         // then
         assertThatThrownBy(() -> authService.login(loginRequest))
-            .isInstanceOf(UserException.class)
-            .hasMessage(UserErrorCode.WRONG_PASSWORD.getMessage());
+            .isInstanceOf(AuthException.class)
+            .hasMessage(AuthErrorCode.WRONG_PASSWORD.getMessage());
+    }
+
+    @Test
+    @DisplayName("올바른 이메일과 비밀번호를 입력하면 access Token과 refresh Token이 반환된다.")
+    void loginSuccessTest() {
+        // given
+        final LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("alswn12345@gmail.com");
+        loginRequest.setPassword("alswn12345");
+
+        // when
+        when(jwtService.generateAccessToken(anyString())).thenReturn("testAccessToken");
+        when(jwtService.generateRefreshToken(anyString())).thenReturn("testRefreshToken");
+        when(userRepository.findByEmail(any(Email.class))).thenReturn(Optional.of(user));
+        final LoginResponse loginResponse = authService.login(loginRequest);
+
+        // then
+        assertAll(
+            () -> assertEquals(loginResponse.getAccessToken(), "testAccessToken"),
+            () -> assertEquals(loginResponse.getRefreshToken(), "testRefreshToken")
+        );
+    }
+
+    @Test
+    @DisplayName("유효한 리프레시 토큰으로 refreshAccessToken을 요청하면 새로운 access token이 반환된다.")
+    void refreshAccessTokenSuccessTest() {
+        // given
+        String refreshTokenValue = "refreshTokenValue";
+
+        // when
+        when(jwtService.validateToken(anyString())).thenReturn(true);
+        when(refreshTokenRepository.findByToken(anyString())).thenReturn(Optional.of(refreshToken));
+        when(jwtService.extractUserEmail(refreshTokenValue)).thenReturn("alswn12345@gmail.com");
+        when(jwtService.generateAccessToken(anyString())).thenReturn("newAccessToken");
+
+        // then
+        ReissueTokenResponse reissueTokenResponse = authService.reissueAccessToken(refreshTokenValue);
+        assertEquals("newAccessToken", reissueTokenResponse.getAccessToken());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 리프레시 토큰으로 예외가 발생한다.")
+    void refreshAccessTokenInvalidTokenTest() {
+        // given
+        String refreshTokenValue = "invalidToken";
+
+        // when
+        when(jwtService.validateToken(refreshTokenValue)).thenReturn(false);
+
+        // then
+        assertThatThrownBy(() -> authService.reissueAccessToken(refreshTokenValue))
+            .isInstanceOf(AuthException.class)
+            .hasMessage(AuthErrorCode.INVALID_REFRESH_TOKEN.getMessage());
+    }
+
+    @Test
+    @DisplayName("만료된 리프레시 토큰으로 예외가 발생한다.")
+    void refreshAccessTokenExpiredTokenTest() {
+        // given
+        String refreshTokenValue = "expiredToken";
+        RefreshToken expiredToken = new RefreshToken(refreshTokenValue, user,
+                                                     new Date(System.currentTimeMillis() - 10000));
+
+        // when
+        when(jwtService.validateToken(anyString())).thenReturn(true);
+        when(refreshTokenRepository.findByToken(refreshTokenValue)).thenReturn(Optional.of(expiredToken));
+
+        // then
+        assertThatThrownBy(() -> authService.reissueAccessToken(refreshTokenValue))
+            .isInstanceOf(AuthException.class)
+            .hasMessage(AuthErrorCode.REFRESH_TOKEN_IS_EXPIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("로그아웃 시 리프레시 토큰이 삭제된다.")
+    void logoutSuccessTest() {
+        // given
+        String refreshTokenValue = "refreshTokenValue";
+
+        // when
+        authService.logout(refreshTokenValue);
+
+        // then
+        Mockito.verify(refreshTokenRepository, times(1))
+            .deleteByToken(refreshTokenValue);
     }
 
 }

--- a/src/test/java/choorai/retrospect/auth/service/AuthServiceTest.java
+++ b/src/test/java/choorai/retrospect/auth/service/AuthServiceTest.java
@@ -1,0 +1,81 @@
+package choorai.retrospect.auth.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import choorai.retrospect.user.entity.User;
+import choorai.retrospect.auth.entity.dto.LoginRequest;
+import choorai.retrospect.auth.entity.dto.LoginResponse;
+import choorai.retrospect.user.entity.repository.UserRepository;
+import choorai.retrospect.user.entity.value.Email;
+import choorai.retrospect.user.exception.UserErrorCode;
+import choorai.retrospect.user.exception.UserException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    AuthService authService;
+
+    @Test
+    @DisplayName(value = "존재하는 이메일과 올바른 비밀번호를 입력하면 로그인에 성공한다.")
+    void successTest() {
+        // given
+        final User user = new User("alswn12345@gmail.com", "alswn12345", "정민주");
+        final LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("alswn12345@gmail.com");
+        loginRequest.setPassword("alswn12345");
+        // when
+        when(userRepository.findByEmail(eq(new Email(loginRequest.getEmail()))))
+            .thenReturn(Optional.of(user));
+        final LoginResponse loginResponse = authService.login(loginRequest);
+        // then
+        assertNotNull(loginResponse);
+    }
+
+    @Test
+    @DisplayName(value = "존재하지 않은 이메일을 입력하면 예외가 발생한다.")
+    void notFoundUserTest() {
+        // given
+        final LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("alswn12345@gmail.com");
+        loginRequest.setPassword("alswn12345");
+        // when
+        when(userRepository.findByEmail(eq(new Email(loginRequest.getEmail()))))
+            .thenReturn(Optional.empty());
+        // then
+        assertThatThrownBy(() -> authService.login(loginRequest))
+            .isInstanceOf(UserException.class)
+            .hasMessage(UserErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName(value = "틀린 비밀번호를 입력하면 예외가 발생한다.")
+    void wrongPasswordTest() {
+        // given
+        final User user = new User("alswn12345@gmail.com", "alswn12345", "정민주");
+        final LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setEmail("alswn12345@gmail.com");
+        loginRequest.setPassword("alswn1111");
+        // when
+        when(userRepository.findByEmail(eq(new Email(loginRequest.getEmail()))))
+            .thenReturn(Optional.of(user));
+        // then
+        assertThatThrownBy(() -> authService.login(loginRequest))
+            .isInstanceOf(UserException.class)
+            .hasMessage(UserErrorCode.WRONG_PASSWORD.getMessage());
+    }
+
+}

--- a/src/test/java/choorai/retrospect/auth/service/JwtServiceTest.java
+++ b/src/test/java/choorai/retrospect/auth/service/JwtServiceTest.java
@@ -1,0 +1,75 @@
+package choorai.retrospect.auth.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JwtServiceTest {
+
+    private final JwtService jwtService = new JwtService("mytestsecretkeymytestsecretkeymytestsecretkey");
+
+    @Test
+    @DisplayName("유효한 access Token을 생성할 수 있다.")
+    void generateAccessTokenTest() {
+        // given
+        String email = "test@example.com";
+        // when
+        String token = jwtService.generateAccessToken(email);
+        // then
+        assertTrue(jwtService.validateToken(token));
+        assertEquals(email, jwtService.extractUserEmail(token));
+    }
+
+    @Test
+    @DisplayName("유효한 refresh Token을 생성할 수 있다.")
+    void generateRefreshTokenTest() {
+        // given
+        String email = "test@example.com";
+        // when
+        String token = jwtService.generateRefreshToken(email);
+        // then
+        assertTrue(jwtService.validateToken(token));
+    }
+
+    @Test
+    @DisplayName("생성 된 토큰에서 userEmail을 추출할 수 있다.")
+    void extractEmailTest() {
+        // given
+        String email = "test@example.com";
+        String token = jwtService.generateAccessToken(email);
+        // when
+        final String extractedUserEmail = jwtService.extractUserEmail(token);
+        // then
+        assertThat(extractedUserEmail)
+            .isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("생성 된 토큰에서 expiration을 추출할 수 있다.")
+    void extractExpirationTest() {
+        // given
+        String email = "test@example.com";
+        String token = jwtService.generateAccessToken(email);
+        // when
+        final Date expiration = jwtService.extractExpiration(token);
+        assertTrue(expiration.after(new Date()));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 token의 validate() 결과는 false이다.")
+    void invalidTokenTest() {
+        String malformedToken = "malformedToken";
+
+        // When
+        boolean isValid = jwtService.validateToken(malformedToken);
+
+        // Then
+        assertFalse(isValid);
+    }
+
+}


### PR DESCRIPTION
## 내용
- 로그인 관련 api를 구현했습니다 (로그인, 로그아웃, refreshAccessToken)
- 로그인에 성공하면 access token, refresh token을 반환합니다.
- refresh token을 활용하여 access token을 새로 발급받을 수도 있습니다.
- refresh token의 경우 db에서 관리하도록 Repository를 생성했습니다. (accessToken까지 db로 관리할 경우 stateless하다는 장점의 의미가 없어질것이라 생각하였고, refreshToken은 최소한의 보안 요소(?)로서 서버에서 관리하는 것이 낫다고 생각했습니다.)
- 로그아웃하는 경우, refresh token은 지울 수 있도록 구현했습니다.


## 고민
- spring security 없이 jwt 인증을 구현하기 위해 filter를 사용했는ㄷㅔ.. 동작을 안합니다ㅠㅠ 도와주세요 ㅠ ㅠ ㅠ
- (사용자 : 토큰) = (1:N)으로 구현했습니다!!!!!! 한 명의 사용자가 여러 디바이스를 사용하게 되어 refresh Token을 여러 개 갖는 경우도 있다고 하더라구요. 이 부분에 대해선 저도 좀 더 알아봐야할 듯 싶습니다.
