### PR TITLE
RH-14 : 공통 ResponseDTO 수정

### DIFF
--- a/src/main/java/choorai/retrospect/auth/ui/AuthController.java
+++ b/src/main/java/choorai/retrospect/auth/ui/AuthController.java
@@ -6,8 +6,8 @@ import choorai.retrospect.auth.entity.dto.LogoutRequest;
 import choorai.retrospect.auth.entity.dto.ReissueTokenRequest;
 import choorai.retrospect.auth.entity.dto.ReissueTokenResponse;
 import choorai.retrospect.auth.service.AuthService;
+import choorai.retrospect.global.response.BaseResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,26 +21,23 @@ public class AuthController {
     private final AuthService userService;
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody final LoginRequest request) {
+    public BaseResponseDto<LoginResponse> login(@RequestBody final LoginRequest request) {
         final LoginResponse loginResponse = userService.login(request);
-        return ResponseEntity.ok()
-            .body(loginResponse);
+        return BaseResponseDto.ofSuccess(loginResponse);
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<ReissueTokenResponse> reissue(@RequestBody final ReissueTokenRequest request) {
+    public BaseResponseDto<ReissueTokenResponse> reissue(@RequestBody final ReissueTokenRequest request) {
         String refreshToken = request.getRefreshToken();
         final ReissueTokenResponse reissueTokenResponse = userService.reissueAccessToken(refreshToken);
-        return ResponseEntity.ok()
-            .body(reissueTokenResponse);
+        return BaseResponseDto.ofSuccess(reissueTokenResponse);
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(@RequestBody final LogoutRequest request) {
+    public BaseResponseDto<String> logout(@RequestBody final LogoutRequest request) {
         final String refreshToken = request.getRefreshToken();
         userService.logout(refreshToken);
-        return ResponseEntity.ok()
-            .body("LOGOUT SUCCESS");
+        return BaseResponseDto.ofSuccess();
     }
 
 }

--- a/src/main/java/choorai/retrospect/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/choorai/retrospect/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package choorai.retrospect.global.exception;
 
 import choorai.retrospect.global.exception.dto.CustomExceptionResponse;
+import choorai.retrospect.global.response.BaseResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,12 +15,14 @@ public class GlobalExceptionHandler {
     private static final String ERROR_LOG_FORMAT_WITH_WRONG_INPUT = "url={}, errorCode={}, errorMessage={}, errorInput={}";
 
     @ExceptionHandler(CommonException.class)
-    public CustomExceptionResponse handleException(
+    public BaseResponseDto<CustomExceptionResponse> handleException(
         final CommonException exception,
         final HttpServletRequest request
     ) {
         trackLog(exception, request);
-        return new CustomExceptionResponse(exception.getCode(), exception.getMessage());
+        final CustomExceptionResponse customExceptionResponse = new CustomExceptionResponse(exception.getCode(),
+                                                                                            exception.getMessage());
+        return BaseResponseDto.ofException(customExceptionResponse);
     }
 
     private void trackLog(final CommonException exception, final HttpServletRequest request) {

--- a/src/main/java/choorai/retrospect/global/response/BaseResponseDto.java
+++ b/src/main/java/choorai/retrospect/global/response/BaseResponseDto.java
@@ -1,0 +1,32 @@
+package choorai.retrospect.global.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor(staticName = "of")
+public class BaseResponseDto<D> {
+
+    private final ResultCode resultCode;
+    private final D data;
+
+
+    public static <D> BaseResponseDto<D> ofSuccess() {
+        return new BaseResponseDto<>(ResultCode.SUCCESS, null);
+    }
+
+    public static <D> BaseResponseDto<D> ofSuccess(D data) {
+        return new BaseResponseDto<>(ResultCode.SUCCESS, data);
+    }
+
+    public static <Exception> BaseResponseDto<Exception> ofException(Exception e) {
+        return new BaseResponseDto<>(ResultCode.FAIL, e);
+    }
+
+    public static <D> BaseResponseDto<D> ofFail() {
+        return new BaseResponseDto<>(ResultCode.FAIL, null);
+    }
+
+}

--- a/src/main/java/choorai/retrospect/global/response/ResultCode.java
+++ b/src/main/java/choorai/retrospect/global/response/ResultCode.java
@@ -1,0 +1,12 @@
+package choorai.retrospect.global.response;
+
+public enum ResultCode {
+    SUCCESS("SUCCESS"),
+    FAIL("FAIL");
+
+    private final String message;
+
+    ResultCode(String message) {
+        this.message = message;
+    }
+}


### PR DESCRIPTION
### 내용

공통 응답 DTO를 생성했습니다.
이에 맞게 "(1) 기존 구현되어있던 auth controller" 와 "(2) @RestControllerAdvice " 코드를 변경하였습니다.

### 고민했던 내용
Exception의 상황이 아닌 ex) 로그인하는데 비밀번호가 잘못된 상황과 같은 경우엔
아래와 같이 200 응답이 오게 되는데

<img width="706" alt="스크린샷 2024-09-09 오후 6 38 47" src="https://github.com/user-attachments/assets/a608f823-d2dd-4eaa-9f64-6ce1996fc615">

위 응답과, 성공했을 때 전달되는 아래의 응답과 차이가 있어 FE 단에서 처리하기가 꽤나 복잡해보였습니다.
<img width="682" alt="스크린샷 2024-09-09 오후 6 39 31" src="https://github.com/user-attachments/assets/8e0f1e96-b692-4481-baa1-6661d70aa508">

그래서 공통 응답 dto를 도입해 복잡도를 줄이고자 결정하였습니다.

### 설계

```
{
  "resultCode": ,
  "data": 
}
```

> 참조 블로그에선 message를 넣었는데, 굳이.. 싶어서 (data에 넣음 되니까) 뺐다.

**😶‍🌫️ resultCode** 는
 - SUCCESS
 - FAIL
 
두 개가 존재.
~간혹 예상치 못한 예외 케이스와, 비밀번호가 잘못된 경우와 같이 비즈니스 로직적인 실패를 다른 케이스로 구분하는 경우도 있는 것 같았는데
그 두 개를 굳이 구분해야할...이유를 못찾았음 ; __ ;~


### Default 생성자

**단순 성공** 

```
{
  "resultCode": "SUCCESS",
  "data": null
}
```

**성공 및 data 반환**
```
{
  "resultCode": ,
  "message": 
  "data": 
}
```
**(기본)실패**

```
{
  "resultCode": "FAIL",
  "data": null
}
```

**예외**
```
{
    "resultCode": "FAIL",
    "data": {
        "errorCode": ",
        "errorMessage": ""
    }
}
```


### 참조 블로그
[주소](https://velog.io/@jomminii/spring-common-response-dto)


### 구현 이후 변경된 api 문서
<img width="722" alt="스크린샷 2024-09-09 오후 7 40 17" src="https://github.com/user-attachments/assets/a8d0f8be-60e5-428a-80c9-19117c4fb2bf">
<img width="694" alt="스크린샷 2024-09-09 오후 7 40 27" src="https://github.com/user-attachments/assets/9187f6b8-23a6-4a79-b681-135b23c11a3f">
<img width="725" alt="스크린샷 2024-09-09 오후 7 40 35" src="https://github.com/user-attachments/assets/da4b3222-ef30-48b0-b13e-b1dcd27be4fe">
