### PR TITLE
RH-18 : User Entity 길이검증 로직 수정

### DIFF
--- a/src/main/java/choorai/retrospect/user/entity/value/Email.java
+++ b/src/main/java/choorai/retrospect/user/entity/value/Email.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 public class Email {
 
     public static final int MIN_LENGTH = 4;
-    public static final int MAX_LENGTH = 255;
+    public static final int MAX_LENGTH = 32;
     private static final Pattern EMAIL_PATTERN
             = Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
 
@@ -37,8 +37,7 @@ public class Email {
     }
 
     private void validateByteLength(String inputValue) {
-        final int inputValueByteLength = inputValue.getBytes(StandardCharsets.UTF_8).length;
-        if (inputValueByteLength < MIN_LENGTH || inputValueByteLength > MAX_LENGTH) {
+        if (inputValue.length() < MIN_LENGTH || inputValue.length() > MAX_LENGTH) {
             throw new UserException(UserErrorCode.EMAIL_LENGTH_ERROR);
         }
     }

--- a/src/main/java/choorai/retrospect/user/entity/value/Name.java
+++ b/src/main/java/choorai/retrospect/user/entity/value/Name.java
@@ -15,8 +15,8 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public class Name {
 
-    public static final int MIN_LENGTH = 6;
-    public static final int MAX_LENGTH = 100;
+    public static final int MIN_LENGTH = 1;
+    public static final int MAX_LENGTH = 20;
 
     @Column(name = "name")
     private String value;
@@ -31,8 +31,7 @@ public class Name {
     }
 
     private void validateByteLength(String inputValue) {
-        final int inputValueByteLength = inputValue.getBytes(StandardCharsets.UTF_8).length;
-        if (inputValueByteLength < MIN_LENGTH || inputValueByteLength> MAX_LENGTH) {
+        if (inputValue.isEmpty() || inputValue.length()> MAX_LENGTH) {
             throw new UserException(UserErrorCode.NAME_LENGTH_ERROR);
         }
     }

--- a/src/main/java/choorai/retrospect/user/entity/value/Password.java
+++ b/src/main/java/choorai/retrospect/user/entity/value/Password.java
@@ -31,8 +31,7 @@ public class Password {
     }
 
     private void validateByteLength(String inputValue) {
-        final int inputValueByteLength = inputValue.getBytes(StandardCharsets.UTF_8).length;
-        if (inputValueByteLength < MIN_LENGTH || inputValueByteLength > MAX_LENGTH) {
+        if (inputValue.length()< MIN_LENGTH || inputValue.length() > MAX_LENGTH) {
             throw new UserException(UserErrorCode.PASSWORD_LENGTH_ERROR);
         }
     }

--- a/src/main/java/choorai/retrospect/user/exception/UserErrorCode.java
+++ b/src/main/java/choorai/retrospect/user/exception/UserErrorCode.java
@@ -10,11 +10,11 @@ public enum UserErrorCode implements ErrorCode {
 
     EMAIL_FORM_ERROR(HttpStatus.BAD_REQUEST, 1001, "이메일 형식이 아닙니다."),
     EMAIL_LENGTH_ERROR(HttpStatus.BAD_REQUEST, 1002,
-                       String.format("이메일은 %d ~ %d 바이트 사이여야합니다.", Email.MIN_LENGTH, Email.MAX_LENGTH)),
+                       String.format("이메일은 %d ~ %d자 사이여야합니다.", Email.MIN_LENGTH, Email.MAX_LENGTH)),
     PASSWORD_LENGTH_ERROR(HttpStatus.BAD_REQUEST, 1003,
-                      String.format("비밀번호는 %d ~ %d 바이트 사이여야 합니다.", Password.MIN_LENGTH, Password.MAX_LENGTH)),
+                      String.format("비밀번호는 %d ~ %d자 사이여야 합니다.", Password.MIN_LENGTH, Password.MAX_LENGTH)),
     NAME_LENGTH_ERROR(HttpStatus.BAD_REQUEST, 1004,
-                      String.format("이름은 %d ~ %d 바이트 사이여야 합니다.", Name.MIN_LENGTH, Name.MAX_LENGTH));
+                      String.format("이름은 %d ~ %d자 사이여야 합니다.", Name.MIN_LENGTH, Name.MAX_LENGTH));
 
     private final HttpStatus httpStatus;
     private final int errorCode;

--- a/src/test/java/choorai/retrospect/user/entity/value/NameTest.java
+++ b/src/test/java/choorai/retrospect/user/entity/value/NameTest.java
@@ -26,7 +26,7 @@ class NameTest {
     }
 
     @ParameterizedTest(name = "{0}은 정해진 이름 길이를 벗어나므로 예외가 발생한다.")
-    @ValueSource(strings = {"", "정", "이 문장은 이름 길이를 초과하는 예시입니다.이 문장은 이름 길이를 초과하는 예시입니다."})
+    @ValueSource(strings = {"", "이 문장은 이름 길이를 초과하는 예시입니다.이 문장은 이름 길이를 초과하는 예시입니다."})
     void lengthErrorTest(String inputValue) {
         // given
         // when

--- a/src/test/java/choorai/retrospect/user/entity/value/PasswordTest.java
+++ b/src/test/java/choorai/retrospect/user/entity/value/PasswordTest.java
@@ -25,7 +25,7 @@ class PasswordTest {
     }
 
     @ParameterizedTest(name = "{0}은 정해진 비밀번호 길이를 벗어나므로 예외가 발생한다.")
-    @ValueSource(strings = {"", "abcd", "이 문장은 한글과 영문, 특수 문자가 혼합되어 있습니다. 영어 단어도 포함됩니다: example. 숫자와 특수 기호: 1234567890!@#$%^&*()_+[]{}|;:',.<>? 이 텍스트는 문자열의 길이를 증가시키기 위해 작성되었습니다. 또 다른 문장을 추가합니다: 이 문장은 255 바이트를 초과하는 예시입니다. 이 문장을 255 바이트를 초과하는 예시입니다."})
+    @ValueSource(strings = {"", "abcd"})
     void lengthErrorTest(String inputValue) {
         // given
         // when


### PR DESCRIPTION
### 내용
기존 byte의 길이로 검증했던 길이검증로직을 'String의 길이'로 검증하도록 로직을 수정하였습니다.
기존 논의했던 다이어그램대로 길이 검증을 수정했는데, 이름의 경우! 찾아보니 **가장 긴 한글이름의 길이가 17자리**라길래 max 20자리로 변경하였습니다 :):)