### PR TITLE
RH-17 : 유효기간 지난 refreshToken 삭제 스케줄러 생성

### DIFF
--- a/src/main/java/choorai/retrospect/RetrospectApplication.java
+++ b/src/main/java/choorai/retrospect/RetrospectApplication.java
@@ -3,8 +3,10 @@ package choorai.retrospect;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class RetrospectApplication {
 

--- a/src/main/java/choorai/retrospect/auth/entity/repository/RefreshTokenRepository.java
+++ b/src/main/java/choorai/retrospect/auth/entity/repository/RefreshTokenRepository.java
@@ -1,6 +1,7 @@
 package choorai.retrospect.auth.entity.repository;
 
 import choorai.retrospect.auth.entity.RefreshToken;
+import java.util.Date;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByToken(String token);
     
     void deleteByToken(String token);
+
+    void deleteByExpiryDateBefore(Date now);
 }

--- a/src/main/java/choorai/retrospect/auth/scheduler/RefreshTokenClearScheduler.java
+++ b/src/main/java/choorai/retrospect/auth/scheduler/RefreshTokenClearScheduler.java
@@ -1,0 +1,20 @@
+package choorai.retrospect.auth.scheduler;
+
+import choorai.retrospect.auth.entity.repository.RefreshTokenRepository;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class RefreshTokenClearScheduler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void cleanUpExpiredTokens() {
+        refreshTokenRepository.deleteByExpiryDateBefore(new Date());
+    }
+
+}

--- a/src/test/java/choorai/retrospect/auth/scheduler/RefreshTokenClearSchedulerTest.java
+++ b/src/test/java/choorai/retrospect/auth/scheduler/RefreshTokenClearSchedulerTest.java
@@ -1,0 +1,30 @@
+package choorai.retrospect.auth.scheduler;
+
+import static org.mockito.Mockito.verify;
+
+import choorai.retrospect.auth.entity.repository.RefreshTokenRepository;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class RefreshTokenClearSchedulerTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private RefreshTokenClearScheduler refreshTokenClearScheduler;
+
+    @Test
+    public void testCleanUpExpiredTokens() {
+        // given
+        MockitoAnnotations.openMocks(this);
+        Date now = new Date();
+        // when
+        refreshTokenClearScheduler.cleanUpExpiredTokens();
+        // then
+        verify(refreshTokenRepository).deleteByExpiryDateBefore(now);
+    }
+}


### PR DESCRIPTION
### 내용
- DB 내에서 유효기간(expiryDate)이 지난 refresh Token을 삭제해줄 수 있는 spring scheduler를 생성.
- **매일 자정** 동작하도록 설정 

### 고민한 내용
- [참조 블로그](https://jofestudio.tistory.com/114)를 봤을 때, refresh token 관리에 주로 Redis를 사용하는 것 같은데 본 프로젝트는 Mysql을 사용하고 있음
- 또한, refresh token을 db에서 지우는 일은 그닥 **무겁지도, 시급하지도, 또 크게 중요하지도** 않다고 생각했음.
- **그래서! 구현하기 제일 간단한 spring scheduler**를 사용했고, **가장 단순하게 자정에 동작하도록** 구현했음


### 구현시 참조한 자료
- [참고 블로그](https://wouldyou.tistory.com/114)

놓친 부분이 있다면 코멘트 부탁드리겠습니다 :)