### PR TITLE
RH-19 : spring security 인증 추가

### DIFF
--- a/src/main/java/choorai/retrospect/auth/JwtAuthFilter.java
+++ b/src/main/java/choorai/retrospect/auth/JwtAuthFilter.java
@@ -40,18 +40,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
         throws IOException, ServletException {
 
-        String requestURI = request.getRequestURI();
+        final String requestURI = request.getRequestURI();
         if (requestURI.startsWith("/auth/")) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        String authHeader = request.getHeader(AUTHORIZATION);
-        if (authHeader == null || !authHeader.startsWith(TOKEN_PREFIX)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
+        final String authHeader = request.getHeader(AUTHORIZATION);
         final String token = authHeader.substring(TOKEN_PREFIX.length());
         final String userEmail = jwtService.extractUserEmail(token);
         if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {

--- a/src/main/java/choorai/retrospect/auth/JwtAuthFilter.java
+++ b/src/main/java/choorai/retrospect/auth/JwtAuthFilter.java
@@ -26,7 +26,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 @Component
 @Slf4j
-@Order(Ordered.HIGHEST_PRECEDENCE)
 public class JwtAuthFilter extends OncePerRequestFilter {
 
     private static final String AUTHORIZATION = "Authorization";
@@ -51,7 +50,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             final UserDetails userDetails = userDetailsService.loadUserByUsername(userEmail);
 
-            if (userDetails.getUsername().equals(userEmail) && jwtService.validateToken(token)) {
+            if (jwtService.isTokenValid(token, userDetails)) {
                 final UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authToken);

--- a/src/main/java/choorai/retrospect/auth/JwtAuthFilter.java
+++ b/src/main/java/choorai/retrospect/auth/JwtAuthFilter.java
@@ -40,13 +40,12 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
         throws IOException, ServletException {
 
-        final String requestURI = request.getRequestURI();
-        if (requestURI.startsWith("/auth/")) {
+        final String authHeader = request.getHeader(AUTHORIZATION);
+        if (authHeader == null || !authHeader.startsWith(TOKEN_PREFIX)) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        final String authHeader = request.getHeader(AUTHORIZATION);
         final String token = authHeader.substring(TOKEN_PREFIX.length());
         final String userEmail = jwtService.extractUserEmail(token);
         if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {

--- a/src/main/java/choorai/retrospect/auth/JwtAuthFilter.java
+++ b/src/main/java/choorai/retrospect/auth/JwtAuthFilter.java
@@ -15,58 +15,56 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
 @Component
 @Slf4j
 @Order(Ordered.HIGHEST_PRECEDENCE)
-public class JwtAuthFilter implements Filter {
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String TOKEN_PREFIX = "Bearer ";
+
 
     private final JwtService jwtService;
-    @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
-        Filter.super.init(filterConfig);
-    }
+    private final UserDetailsService userDetailsService;
 
     @Override
-    public void destroy() {
-        Filter.super.destroy();
-    }
-
-    @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+    public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
         throws IOException, ServletException {
-        HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
-        HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
 
-        String requestURI = httpRequest.getRequestURI();
+        String requestURI = request.getRequestURI();
         if (requestURI.startsWith("/auth/")) {
-            filterChain.doFilter(servletRequest, servletResponse);
+            filterChain.doFilter(request, response);
             return;
         }
 
-        String authHeader = httpRequest.getHeader("Authorization");
+        String authHeader = request.getHeader(AUTHORIZATION);
+        if (authHeader == null || !authHeader.startsWith(TOKEN_PREFIX)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
-        if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            String token = authHeader.substring(7);
-            try {
-                if (jwtService.validateToken(token)) {
-                    String userEmail = jwtService.extractUserEmail(token);
-                    httpRequest.setAttribute("userEmail", userEmail);
-                } else {
-                    httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "JWT가 유효하지 않습니다.");
-                    return;
-                }
-            } catch (JwtException e) {
-                httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "JWT 검증 작업 중 예외가 발생했습니다.");
-                return;
+        final String token = authHeader.substring(TOKEN_PREFIX.length());
+        final String userEmail = jwtService.extractUserEmail(token);
+        if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            final UserDetails userDetails = userDetailsService.loadUserByUsername(userEmail);
+
+            if (userDetails.getUsername().equals(userEmail) && jwtService.validateToken(token)) {
+                final UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
             }
-        } else {
-            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증을 위한 헤더가 존재하지 않습니다.");
-            return;
         }
 
-        filterChain.doFilter(servletRequest, servletResponse);
+
+        filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/choorai/retrospect/auth/service/AuthService.java
+++ b/src/main/java/choorai/retrospect/auth/service/AuthService.java
@@ -29,7 +29,7 @@ public class AuthService {
     @Transactional
     public LoginResponse login(LoginRequest request) {
         final User findUser = getUser(request);
-        if (!findUser.getPassword().isEqual(request.getPassword())) {
+        if (!findUser.getPassword().equals(request.getPassword())) {
             throw new AuthException(AuthErrorCode.WRONG_PASSWORD);
         }
         final String accessToken = jwtService.generateAccessToken(request.getEmail());

--- a/src/main/java/choorai/retrospect/auth/service/JwtService.java
+++ b/src/main/java/choorai/retrospect/auth/service/JwtService.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,7 +19,6 @@ public class JwtService {
     private final long REFRESH_TOKEN_VALIDITY = 1000 * 60 * 60 * 24 * 7; // 7일
 
     private final Key secretKey;
-
 
     public JwtService(@Value("${jwt.secret.key}") String secret) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
@@ -49,6 +49,15 @@ public class JwtService {
             .parseClaimsJws(accessToken)
             .getBody();
         return claims.getSubject();
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        final String username = extractUserEmail(token);
+        return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/choorai/retrospect/config/ApplicationConfig.java
+++ b/src/main/java/choorai/retrospect/config/ApplicationConfig.java
@@ -1,0 +1,23 @@
+package choorai.retrospect.config;
+
+import choorai.retrospect.auth.exception.AuthErrorCode;
+import choorai.retrospect.auth.exception.AuthException;
+import choorai.retrospect.user.entity.repository.UserRepository;
+import choorai.retrospect.user.entity.value.Email;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+@RequiredArgsConstructor
+@Configuration
+public class ApplicationConfig {
+
+    private final UserRepository userRepository;
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return username -> userRepository.findByEmail(new Email(username))
+            .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/choorai/retrospect/config/ApplicationConfig.java
+++ b/src/main/java/choorai/retrospect/config/ApplicationConfig.java
@@ -7,7 +7,13 @@ import choorai.retrospect.user.entity.value.Email;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @RequiredArgsConstructor
 @Configuration
@@ -19,5 +25,18 @@ public class ApplicationConfig {
     public UserDetailsService userDetailsService() {
         return username -> userRepository.findByEmail(new Email(username))
             .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService());
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/choorai/retrospect/config/security/SecurityConfiguration.java
+++ b/src/main/java/choorai/retrospect/config/security/SecurityConfiguration.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -25,6 +26,7 @@ import static org.springframework.security.web.util.matcher.AntPathRequestMatche
 public class SecurityConfiguration {
 
     private final JwtAuthFilter jwtAuthFilter;
+    private final AuthenticationProvider authenticationProvider;
 
     @Bean
     @Order(1)
@@ -51,6 +53,7 @@ public class SecurityConfiguration {
                 auth.requestMatchers(antMatcher("/auth/**")).permitAll();
                 auth.anyRequest().authenticated();
             })
+            .authenticationProvider(authenticationProvider)
             .build();
     }
 

--- a/src/main/java/choorai/retrospect/user/entity/User.java
+++ b/src/main/java/choorai/retrospect/user/entity/User.java
@@ -4,15 +4,22 @@ import choorai.retrospect.global.domain.BaseEntity;
 import choorai.retrospect.user.entity.value.Email;
 import choorai.retrospect.user.entity.value.Name;
 import choorai.retrospect.user.entity.value.Password;
+import choorai.retrospect.user.entity.value.Role;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class User extends BaseEntity {
+public class User extends BaseEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,6 +40,9 @@ public class User extends BaseEntity {
 
     private String companyName;
 
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
     public User(String email, String password, String name, String companyName, String department, String position) {
         this.email = new Email(email);
         this.password = new Password(password);
@@ -46,5 +56,20 @@ public class User extends BaseEntity {
         this.email = new Email(email);
         this.password = new Password(password);
         this.name = new Name(name);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role.name()));
+    }
+
+    @Override
+    public String getUsername() {
+        return email.getValue();
+    }
+
+    @Override
+    public String getPassword() {
+        return password.getValue();
     }
 }

--- a/src/main/java/choorai/retrospect/user/entity/value/Role.java
+++ b/src/main/java/choorai/retrospect/user/entity/value/Role.java
@@ -1,0 +1,5 @@
+package choorai.retrospect.user.entity.value;
+
+public enum Role {
+    ADMIN, USER
+}

--- a/src/test/java/choorai/retrospect/user/entity/UserTest.java
+++ b/src/test/java/choorai/retrospect/user/entity/UserTest.java
@@ -23,7 +23,7 @@ class UserTest {
                 .isEqualTo(emailInput),
             () -> assertThat(user.getName().getValue())
                 .isEqualTo(nameInput),
-            () -> assertThat(user.getPassword().getValue())
+            () -> assertThat(user.getPassword())
                 .isEqualTo(passwordInput)
         );
     }
@@ -46,7 +46,7 @@ class UserTest {
                 .isEqualTo(emailInput),
             () -> assertThat(user.getName().getValue())
                 .isEqualTo(nameInput),
-            () -> assertThat(user.getPassword().getValue())
+            () -> assertThat(user.getPassword())
                 .isEqualTo(passwordInput),
             () -> assertThat(user.getCompanyName())
                 .isEqualTo(companyInput),


### PR DESCRIPTION
jira 티켓 : https://choorai.atlassian.net/jira/software/projects/RH/boards/1?selectedIssue=RH-19

## 진행사항
### JwtAuthFilter 내 건너뛰기 분기문 제거
기존 JwtAuthFilter 내에 요청 url을 구분해서 해당 Filter가 동작할지 안할지를 선정했었습니다. 하지만 이제는 security configuration에서 해당 filter를 관리해서 인증이 필요한 요청에 대해서만 동작하기 때문에 앞선 분기문이 불 필요해서 제거했습니다.

### AuthenticationProvider 활용
`AuthenticationProvider`는 security에서 인증을 처리하는 인터페이스 입니다. 현재 `DaoAuthenticationProvider`로 db를 통해 인증작업을 하는 것을 설정을 했습니다.
다만 고민이 되는 점은 `AuthenticationManager`가 전반적인 인증체계를 담당하고 `AuthenticationProvider`가 직접 인증을 처리하는 역할을 하는 것인데 현재는 `AuthenticationProvider`가 현재는 하나여서 `AuthenticationManager`를 거치지 않고 바로 `Provider`를 접근하는 방안을 택했습니다. 
이 부분에 대해서 다른 의견이 있다면 말해주세요!

security 인증 처리를 처음해보는 것이라 미숙한 점이 많을 것 같아서 꼼꼼한 리뷰 부탁드립니다!