### PR TITLE
RH-22 : Card 엔티티 생성

### DIFF
--- a/src/main/java/choorai/retrospect/config/security/SecurityConfiguration.java
+++ b/src/main/java/choorai/retrospect/config/security/SecurityConfiguration.java
@@ -49,6 +49,7 @@ public class SecurityConfiguration {
             .formLogin(AbstractHttpConfigurer::disable)
             .cors(config -> config.configurationSource(corsConfigurationSource()))
             .authorizeHttpRequests(auth -> {
+                auth.requestMatchers(antMatcher("/**")).permitAll();
                 auth.requestMatchers(antMatcher("/auth/**")).permitAll();
                 auth.anyRequest().authenticated();
             })

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/Card.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/Card.java
@@ -96,7 +96,4 @@ public class Card extends BaseEntity {
         }
     }
 
-    public boolean isInRoom(final Long retrospectRoomId) {
-        return Objects.equals(retrospectRoom.getId(), retrospectRoomId);
-    }
 }

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/Card.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/Card.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -43,7 +42,8 @@ public class Card extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    private Card(Long id, Type type, String content, RetrospectRoom retrospectRoom, User user) {
+    private Card(final Long id, final Type type, final String content, final RetrospectRoom retrospectRoom,
+                 final User user) {
         this.id = id;
         this.type = type;
         this.content = content;
@@ -51,23 +51,25 @@ public class Card extends BaseEntity {
         this.user = user;
     }
 
-    public static Card forSave(String type, String content, RetrospectRoom retrospectRoom, User user) {
+    public static Card forSave(final String type, final String content, final RetrospectRoom retrospectRoom,
+                               final User user) {
         validateParameter(type, content, retrospectRoom, user);
         return new Card(null,
-                        Type.valueOf(type),
+                        Type.fromString(type),
                         content,
                         retrospectRoom,
                         user);
     }
 
-    private static void validateParameter(String type, String content, RetrospectRoom retrospectRoom, User user) {
+    private static void validateParameter(final String type, final String content, final RetrospectRoom retrospectRoom,
+                                          final User user) {
         validateType(type);
         validateContent(content);
         validateRetrospectRoom(retrospectRoom);
         validateUser(user);
     }
 
-    private static void validateType(String type) throws CardException {
+    private static void validateType(final String type) throws CardException {
         if (type == null || type.isEmpty()) {
             throw new CardException(CardErrorCode.TYPE_IS_NOT_NULL);
         }
@@ -76,25 +78,25 @@ public class Card extends BaseEntity {
         }
     }
 
-    private static void validateContent(String content) {
+    private static void validateContent(final String content) {
         if (content == null || content.isEmpty()) {
             throw new CardException(CardErrorCode.CONTENT_IS_NOT_NULL);
         }
     }
 
-    private static void validateRetrospectRoom(RetrospectRoom retrospectRoom) {
+    private static void validateRetrospectRoom(final RetrospectRoom retrospectRoom) {
         if (retrospectRoom == null) {
             throw new CardException(CardErrorCode.RETROSPECT_ROOM_IS_NOT_NULL);
         }
     }
 
-    private static void validateUser(User user) {
+    private static void validateUser(final User user) {
         if (user == null) {
             throw new CardException(CardErrorCode.USER_IS_NOT_NULL);
         }
     }
 
-    public boolean isInRoom(Long retrospectRoomId) {
+    public boolean isInRoom(final Long retrospectRoomId) {
         return Objects.equals(retrospectRoom.getId(), retrospectRoomId);
     }
 }

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/Card.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/Card.java
@@ -1,0 +1,100 @@
+package choorai.retrospect.retrospect_room.card.entity;
+
+import choorai.retrospect.global.domain.BaseEntity;
+import choorai.retrospect.retrospect_room.card.entity.value.Type;
+import choorai.retrospect.retrospect_room.card.exception.CardErrorCode;
+import choorai.retrospect.retrospect_room.card.exception.CardException;
+import choorai.retrospect.retrospect_room.entity.RetrospectRoom;
+import choorai.retrospect.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Card extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+    private String content;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "retrospect_room_id")
+    private RetrospectRoom retrospectRoom;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private Card(Long id, Type type, String content, RetrospectRoom retrospectRoom, User user) {
+        this.id = id;
+        this.type = type;
+        this.content = content;
+        this.retrospectRoom = retrospectRoom;
+        this.user = user;
+    }
+
+    public static Card forSave(String type, String content, RetrospectRoom retrospectRoom, User user) {
+        validateParameter(type, content, retrospectRoom, user);
+        return new Card(null,
+                        Type.valueOf(type),
+                        content,
+                        retrospectRoom,
+                        user);
+    }
+
+    private static void validateParameter(String type, String content, RetrospectRoom retrospectRoom, User user) {
+        validateType(type);
+        validateContent(content);
+        validateRetrospectRoom(retrospectRoom);
+        validateUser(user);
+    }
+
+    private static void validateType(String type) throws CardException {
+        if (type == null || type.isEmpty()) {
+            throw new CardException(CardErrorCode.TYPE_IS_NOT_NULL);
+        }
+        if (!Type.isValidType(type)) {
+            throw new CardException(CardErrorCode.INVALID_TYPE);
+        }
+    }
+
+    private static void validateContent(String content) {
+        if (content == null || content.isEmpty()) {
+            throw new CardException(CardErrorCode.CONTENT_IS_NOT_NULL);
+        }
+    }
+
+    private static void validateRetrospectRoom(RetrospectRoom retrospectRoom) {
+        if (retrospectRoom == null) {
+            throw new CardException(CardErrorCode.RETROSPECT_ROOM_IS_NOT_NULL);
+        }
+    }
+
+    private static void validateUser(User user) {
+        if (user == null) {
+            throw new CardException(CardErrorCode.USER_IS_NOT_NULL);
+        }
+    }
+
+    public boolean isInRoom(Long retrospectRoomId) {
+        return Objects.equals(retrospectRoom.getId(), retrospectRoomId);
+    }
+}

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/Card.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/Card.java
@@ -1,11 +1,11 @@
 package choorai.retrospect.retrospect_room.card.entity;
 
 import choorai.retrospect.global.domain.BaseEntity;
+import choorai.retrospect.retrospect_room.card.entity.value.Content;
 import choorai.retrospect.retrospect_room.card.entity.value.Type;
-import choorai.retrospect.retrospect_room.card.exception.CardErrorCode;
-import choorai.retrospect.retrospect_room.card.exception.CardException;
 import choorai.retrospect.retrospect_room.entity.RetrospectRoom;
 import choorai.retrospect.user.entity.User;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -15,7 +15,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,7 +31,8 @@ public class Card extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Type type;
 
-    private String content;
+    @Embedded
+    private Content content;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "retrospect_room_id")
@@ -42,7 +42,7 @@ public class Card extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    private Card(final Long id, final Type type, final String content, final RetrospectRoom retrospectRoom,
+    private Card(final Long id, final Type type, final Content content, final RetrospectRoom retrospectRoom,
                  final User user) {
         this.id = id;
         this.type = type;
@@ -53,47 +53,11 @@ public class Card extends BaseEntity {
 
     public static Card forSave(final String type, final String content, final RetrospectRoom retrospectRoom,
                                final User user) {
-        validateParameter(type, content, retrospectRoom, user);
         return new Card(null,
                         Type.fromString(type),
-                        content,
+                        new Content(content),
                         retrospectRoom,
                         user);
-    }
-
-    private static void validateParameter(final String type, final String content, final RetrospectRoom retrospectRoom,
-                                          final User user) {
-        validateType(type);
-        validateContent(content);
-        validateRetrospectRoom(retrospectRoom);
-        validateUser(user);
-    }
-
-    private static void validateType(final String type) throws CardException {
-        if (type == null || type.isEmpty()) {
-            throw new CardException(CardErrorCode.TYPE_IS_NOT_NULL);
-        }
-        if (!Type.isValidType(type)) {
-            throw new CardException(CardErrorCode.INVALID_TYPE);
-        }
-    }
-
-    private static void validateContent(final String content) {
-        if (content == null || content.isEmpty()) {
-            throw new CardException(CardErrorCode.CONTENT_IS_NOT_NULL);
-        }
-    }
-
-    private static void validateRetrospectRoom(final RetrospectRoom retrospectRoom) {
-        if (retrospectRoom == null) {
-            throw new CardException(CardErrorCode.RETROSPECT_ROOM_IS_NOT_NULL);
-        }
-    }
-
-    private static void validateUser(final User user) {
-        if (user == null) {
-            throw new CardException(CardErrorCode.USER_IS_NOT_NULL);
-        }
     }
 
 }

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/repository/CardRepository.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/repository/CardRepository.java
@@ -1,16 +1,12 @@
 package choorai.retrospect.retrospect_room.card.entity.repository;
 
 import choorai.retrospect.retrospect_room.entity.RetrospectRoom;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public class CardRepository {
 
     public interface RetrospectRoomRepository extends JpaRepository<RetrospectRoom, Long> {
 
-        @EntityGraph(attributePaths = {"cards"})
-        Optional<RetrospectRoom> findWithCardsById(final Long userId);
     }
 
 }

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/repository/CardRepository.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/repository/CardRepository.java
@@ -10,7 +10,7 @@ public class CardRepository {
     public interface RetrospectRoomRepository extends JpaRepository<RetrospectRoom, Long> {
 
         @EntityGraph(attributePaths = {"cards"})
-        Optional<RetrospectRoom> findWithCardsById(Long userId);
+        Optional<RetrospectRoom> findWithCardsById(final Long userId);
     }
 
 }

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/repository/CardRepository.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/repository/CardRepository.java
@@ -1,0 +1,16 @@
+package choorai.retrospect.retrospect_room.card.entity.repository;
+
+import choorai.retrospect.retrospect_room.entity.RetrospectRoom;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public class CardRepository {
+
+    public interface RetrospectRoomRepository extends JpaRepository<RetrospectRoom, Long> {
+
+        @EntityGraph(attributePaths = {"cards"})
+        Optional<RetrospectRoom> findWithCardsById(Long userId);
+    }
+
+}

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/value/Content.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/value/Content.java
@@ -2,17 +2,26 @@ package choorai.retrospect.retrospect_room.card.entity.value;
 
 import choorai.retrospect.retrospect_room.card.exception.CardErrorCode;
 import choorai.retrospect.retrospect_room.card.exception.CardException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
 public class Content {
 
+    @Column(name = "content")
     private String value;
 
     public Content(final String value) {
-        validateContent(value);
+        validate(value);
         this.value = value;
     }
 
-    private void validateContent(final String content) {
+    private void validate(final String content) {
         if (content == null || content.isEmpty()) {
             throw new CardException(CardErrorCode.CONTENT_IS_NOT_NULL);
         }

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/value/Content.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/value/Content.java
@@ -1,0 +1,21 @@
+package choorai.retrospect.retrospect_room.card.entity.value;
+
+import choorai.retrospect.retrospect_room.card.exception.CardErrorCode;
+import choorai.retrospect.retrospect_room.card.exception.CardException;
+
+public class Content {
+
+    private String value;
+
+    public Content(final String value) {
+        validateContent(value);
+        this.value = value;
+    }
+
+    private void validateContent(final String content) {
+        if (content == null || content.isEmpty()) {
+            throw new CardException(CardErrorCode.CONTENT_IS_NOT_NULL);
+        }
+    }
+
+}

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/value/Type.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/value/Type.java
@@ -1,0 +1,14 @@
+package choorai.retrospect.retrospect_room.card.entity.value;
+
+import java.util.Arrays;
+
+public enum Type {
+
+    KEEP, PROBLEM, TRY;
+
+    public static boolean isValidType(String type) {
+        return Arrays.stream(Type.values())
+            .anyMatch(enumValue -> enumValue.name().equals(type));
+    }
+
+}

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/value/Type.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/value/Type.java
@@ -1,5 +1,7 @@
 package choorai.retrospect.retrospect_room.card.entity.value;
 
+import choorai.retrospect.retrospect_room.card.exception.CardErrorCode;
+import choorai.retrospect.retrospect_room.card.exception.CardException;
 import java.util.Arrays;
 
 public enum Type {
@@ -7,10 +9,20 @@ public enum Type {
     KEEP, PROBLEM, TRY;
 
     public static Type fromString(final String type) {
+        validateType(type);
         return Type.valueOf(type.toUpperCase());
     }
 
-    public static boolean isValidType(final String type) {
+    private static void validateType(final String type) {
+        if (type == null || type.isEmpty()) {
+            throw new CardException(CardErrorCode.TYPE_IS_NOT_NULL);
+        }
+        if(!isValidType(type)) {
+            throw new CardException(CardErrorCode.INVALID_TYPE);
+        }
+    }
+
+    private static boolean isValidType(final String type) {
         return Arrays.stream(Type.values())
             .anyMatch(enumValue -> enumValue.name().equals(type.toUpperCase()));
     }

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/value/Type.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/value/Type.java
@@ -6,11 +6,11 @@ public enum Type {
 
     KEEP, PROBLEM, TRY;
 
-    public static Type fromString(String type) {
+    public static Type fromString(final String type) {
         return Type.valueOf(type.toUpperCase());
     }
 
-    public static boolean isValidType(String type) {
+    public static boolean isValidType(final String type) {
         return Arrays.stream(Type.values())
             .anyMatch(enumValue -> enumValue.name().equals(type.toUpperCase()));
     }

--- a/src/main/java/choorai/retrospect/retrospect_room/card/entity/value/Type.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/entity/value/Type.java
@@ -6,9 +6,13 @@ public enum Type {
 
     KEEP, PROBLEM, TRY;
 
+    public static Type fromString(String type) {
+        return Type.valueOf(type.toUpperCase());
+    }
+
     public static boolean isValidType(String type) {
         return Arrays.stream(Type.values())
-            .anyMatch(enumValue -> enumValue.name().equals(type));
+            .anyMatch(enumValue -> enumValue.name().equals(type.toUpperCase()));
     }
 
 }

--- a/src/main/java/choorai/retrospect/retrospect_room/card/exception/CardErrorCode.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/exception/CardErrorCode.java
@@ -1,0 +1,40 @@
+package choorai.retrospect.retrospect_room.card.exception;
+
+import choorai.retrospect.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum CardErrorCode implements ErrorCode {
+
+    CONTENT_IS_NOT_NULL(HttpStatus.BAD_REQUEST, 4001, "content는 필수값 입니다."),
+    TYPE_IS_NOT_NULL(HttpStatus.BAD_REQUEST, 4002, "type은 필수값 입니다."),
+    INVALID_TYPE(HttpStatus.BAD_REQUEST, 4003, "type은 KEEP, PROBLEM, TRY 중 하나여야 합니다."),
+    RETROSPECT_ROOM_IS_NOT_NULL(HttpStatus.BAD_REQUEST, 4004, "retrospectRoom은 필수값입니다."),
+    USER_IS_NOT_NULL(HttpStatus.BAD_REQUEST, 4005, "user은 필수값입니다."),
+    CARD_NOT_FOUND_FOR_ID(HttpStatus.BAD_REQUEST, 4006, "동일한 id를 가진 card를 찾을 수 없습니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final int errorCode;
+    private final String errorMessage;
+
+    CardErrorCode(HttpStatus httpStatus, int errorCode, String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public int getCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/choorai/retrospect/retrospect_room/card/exception/CardErrorCode.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/exception/CardErrorCode.java
@@ -17,7 +17,7 @@ public enum CardErrorCode implements ErrorCode {
     private final int errorCode;
     private final String errorMessage;
 
-    CardErrorCode(HttpStatus httpStatus, int errorCode, String errorMessage) {
+    CardErrorCode(final HttpStatus httpStatus, final int errorCode, final String errorMessage) {
         this.httpStatus = httpStatus;
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;

--- a/src/main/java/choorai/retrospect/retrospect_room/card/exception/CardException.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/exception/CardException.java
@@ -6,11 +6,11 @@ import java.util.Map;
 
 public class CardException extends CommonException {
 
-    public CardException(ErrorCode errorCode) {
+    public CardException(final ErrorCode errorCode) {
         super(errorCode);
     }
 
-    public CardException(ErrorCode errorCode, Map<String, Object> additionalInfo) {
+    public CardException(final ErrorCode errorCode, final Map<String, Object> additionalInfo) {
         super(errorCode, additionalInfo);
     }
 }

--- a/src/main/java/choorai/retrospect/retrospect_room/card/exception/CardException.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/card/exception/CardException.java
@@ -1,0 +1,16 @@
+package choorai.retrospect.retrospect_room.card.exception;
+
+import choorai.retrospect.global.exception.CommonException;
+import choorai.retrospect.global.exception.ErrorCode;
+import java.util.Map;
+
+public class CardException extends CommonException {
+
+    public CardException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public CardException(ErrorCode errorCode, Map<String, Object> additionalInfo) {
+        super(errorCode, additionalInfo);
+    }
+}

--- a/src/main/java/choorai/retrospect/retrospect_room/entity/RetrospectRoom.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/entity/RetrospectRoom.java
@@ -57,12 +57,12 @@ public class RetrospectRoom extends BaseEntity {
             new ShareLink(shareLink));
     }
 
-    public void addCard(Card card) {
+    public void addCard(final Card card) {
         this.cards.add(card);
     }
 
-    public void removeCardById(Long cardId) {
-        boolean removed = cards.removeIf(card -> card.getId().equals(cardId));
+    public void removeCardById(final Long cardId) {
+        boolean removed = this.cards.removeIf(card -> card.getId().equals(cardId));
         if (!removed) {
             throw new CardException(CardErrorCode.CARD_NOT_FOUND_FOR_ID);
         }

--- a/src/main/java/choorai/retrospect/retrospect_room/entity/RetrospectRoom.java
+++ b/src/main/java/choorai/retrospect/retrospect_room/entity/RetrospectRoom.java
@@ -1,8 +1,13 @@
 package choorai.retrospect.retrospect_room.entity;
 
 import choorai.retrospect.global.domain.BaseEntity;
+import choorai.retrospect.retrospect_room.card.entity.Card;
+import choorai.retrospect.retrospect_room.card.exception.CardErrorCode;
+import choorai.retrospect.retrospect_room.card.exception.CardException;
 import choorai.retrospect.retrospect_room.entity.value.*;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,6 +36,9 @@ public class RetrospectRoom extends BaseEntity {
     @Embedded
     private ShareLink shareLink;
 
+    @OneToMany(mappedBy = "retrospectRoom", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Card> cards = new ArrayList<>();
+
     private RetrospectRoom(final Long id, final Subject subject, final Details details, final Type type, final TimeLimit timeLimit, final ShareLink shareLink) {
         this.id = id;
         this.subject = subject;
@@ -47,5 +55,16 @@ public class RetrospectRoom extends BaseEntity {
             Type.valueOf(type),
             TimeLimit.from(timeLimit),
             new ShareLink(shareLink));
+    }
+
+    public void addCard(Card card) {
+        this.cards.add(card);
+    }
+
+    public void removeCardById(Long cardId) {
+        boolean removed = cards.removeIf(card -> card.getId().equals(cardId));
+        if (!removed) {
+            throw new CardException(CardErrorCode.CARD_NOT_FOUND_FOR_ID);
+        }
     }
 }

--- a/src/main/java/choorai/retrospect/user/entity/User.java
+++ b/src/main/java/choorai/retrospect/user/entity/User.java
@@ -2,6 +2,8 @@ package choorai.retrospect.user.entity;
 
 import choorai.retrospect.global.domain.BaseEntity;
 import choorai.retrospect.retrospect_room.card.entity.Card;
+import choorai.retrospect.retrospect_room.card.exception.CardErrorCode;
+import choorai.retrospect.retrospect_room.card.exception.CardException;
 import choorai.retrospect.user.entity.value.Email;
 import choorai.retrospect.user.entity.value.Name;
 import choorai.retrospect.user.entity.value.Password;
@@ -46,6 +48,9 @@ public class User extends BaseEntity implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Card> cards = new ArrayList<>();
+
     public User(String email, String password, String name, String companyName, String department, String position, Role role) {
         this.email = new Email(email);
         this.password = new Password(password);
@@ -75,5 +80,16 @@ public class User extends BaseEntity implements UserDetails {
     @Override
     public String getPassword() {
         return password.getValue();
+    }
+
+    public void addCard(Card card) {
+        this.cards.add(card);
+    }
+
+    public void removeCardById(Long cardId) {
+        boolean removed = cards.removeIf(card -> card.getId().equals(cardId));
+        if (!removed) {
+            throw new CardException(CardErrorCode.CARD_NOT_FOUND_FOR_ID);
+        }
     }
 }

--- a/src/main/java/choorai/retrospect/user/entity/User.java
+++ b/src/main/java/choorai/retrospect/user/entity/User.java
@@ -1,11 +1,13 @@
 package choorai.retrospect.user.entity;
 
 import choorai.retrospect.global.domain.BaseEntity;
+import choorai.retrospect.retrospect_room.card.entity.Card;
 import choorai.retrospect.user.entity.value.Email;
 import choorai.retrospect.user.entity.value.Name;
 import choorai.retrospect.user.entity.value.Password;
 import choorai.retrospect.user.entity.value.Role;
 import jakarta.persistence.*;
+import java.util.ArrayList;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -44,13 +46,14 @@ public class User extends BaseEntity implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    public User(String email, String password, String name, String companyName, String department, String position) {
+    public User(String email, String password, String name, String companyName, String department, String position, Role role) {
         this.email = new Email(email);
         this.password = new Password(password);
         this.name = new Name(name);
         this.companyName = companyName;
         this.department = department;
         this.position = position;
+        this.role = role;
     }
 
     public User(String email, String password, String name) {

--- a/src/main/java/choorai/retrospect/user/entity/User.java
+++ b/src/main/java/choorai/retrospect/user/entity/User.java
@@ -82,11 +82,11 @@ public class User extends BaseEntity implements UserDetails {
         return password.getValue();
     }
 
-    public void addCard(Card card) {
+    public void addCard(final Card card) {
         this.cards.add(card);
     }
 
-    public void removeCardById(Long cardId) {
+    public void removeCardById(final Long cardId) {
         boolean removed = cards.removeIf(card -> card.getId().equals(cardId));
         if (!removed) {
             throw new CardException(CardErrorCode.CARD_NOT_FOUND_FOR_ID);

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -9,3 +9,16 @@ CREATE TABLE if NOT EXISTS retrospect_room
     created_at datetime(6),
     updated_at datetime(6)
 );
+
+CREATE TABLE if NOT EXISTS card
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    content    VARCHAR(255),
+    type       enum('KEEP','PROBLEM','TRY'),
+    retrospect_room_id BIGINT,
+    user_id BIGINT,
+    created_at datetime(6),
+    updated_at datetime(6),
+    CONSTRAINT fk_retrospect_room FOREIGN KEY (retrospect_room_id) REFERENCES retrospect_room(id),
+    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES user(id)
+);

--- a/src/test/java/choorai/retrospect/retrospect_room/card/entity/CardTest.java
+++ b/src/test/java/choorai/retrospect/retrospect_room/card/entity/CardTest.java
@@ -1,0 +1,70 @@
+package choorai.retrospect.retrospect_room.card.entity;
+
+import static choorai.retrospect.retrospect_room.card.exception.CardErrorCode.CONTENT_IS_NOT_NULL;
+import static choorai.retrospect.retrospect_room.card.exception.CardErrorCode.INVALID_TYPE;
+import static choorai.retrospect.retrospect_room.card.exception.CardErrorCode.RETROSPECT_ROOM_IS_NOT_NULL;
+import static choorai.retrospect.retrospect_room.card.exception.CardErrorCode.USER_IS_NOT_NULL;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import choorai.retrospect.retrospect_room.card.exception.CardException;
+import choorai.retrospect.retrospect_room.entity.RetrospectRoom;
+import choorai.retrospect.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CardTest {
+
+    private static final String type = "KEEP";
+    private static final String content = "내용";
+    private static final RetrospectRoom retrospectRoom = RetrospectRoom.forSave("회고주제", "회고 상새 내용", "KPT", "01:00:00",
+                                                                                "shareLink");
+    private static final User user = new User("alafl@test.com", "afpafdjp132", "테스터");
+
+    @DisplayName("Card의 content가 비어있음 예외가 발생한다.")
+    @Test
+    void nullContentTest() {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> Card.forSave(type, null, retrospectRoom, user))
+            .isInstanceOf(CardException.class)
+            .hasMessage(CONTENT_IS_NOT_NULL.getMessage());
+    }
+
+    @DisplayName("Card의 retrospectRoom이 비어있음 예외가 발생한다.")
+    @Test
+    void nullRetrospectRoomTest() {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> Card.forSave(type, content, null, user))
+            .isInstanceOf(CardException.class)
+            .hasMessage(RETROSPECT_ROOM_IS_NOT_NULL.getMessage());
+    }
+
+    @DisplayName("Card의 User이 비어있음 예외가 발생한다.")
+    @Test
+    void nullUserTest() {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> Card.forSave(type, content, retrospectRoom, null))
+            .isInstanceOf(CardException.class)
+            .hasMessage(USER_IS_NOT_NULL.getMessage());
+    }
+
+    @DisplayName("Card의 Type이 유효한 type(KEEP, PROBLEM, TRY)이 아니면 예외가 발생한다.")
+    @Test
+    void invalidTypeTest() {
+        // given
+        String invalidType = "k";
+        // when
+        // then
+        assertThatThrownBy(() -> Card.forSave(invalidType, content, retrospectRoom, user))
+            .isInstanceOf(CardException.class)
+            .hasMessage(INVALID_TYPE.getMessage());
+    }
+
+}

--- a/src/test/java/choorai/retrospect/retrospect_room/card/entity/CardTest.java
+++ b/src/test/java/choorai/retrospect/retrospect_room/card/entity/CardTest.java
@@ -5,8 +5,6 @@ import static choorai.retrospect.retrospect_room.card.exception.CardErrorCode.IN
 import static choorai.retrospect.retrospect_room.card.exception.CardErrorCode.RETROSPECT_ROOM_IS_NOT_NULL;
 import static choorai.retrospect.retrospect_room.card.exception.CardErrorCode.USER_IS_NOT_NULL;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import choorai.retrospect.retrospect_room.card.exception.CardException;
 import choorai.retrospect.retrospect_room.entity.RetrospectRoom;
@@ -31,28 +29,6 @@ class CardTest {
         assertThatThrownBy(() -> Card.forSave(type, null, retrospectRoom, user))
             .isInstanceOf(CardException.class)
             .hasMessage(CONTENT_IS_NOT_NULL.getMessage());
-    }
-
-    @DisplayName("Card의 retrospectRoom이 비어있음 예외가 발생한다.")
-    @Test
-    void nullRetrospectRoomTest() {
-        // given
-        // when
-        // then
-        assertThatThrownBy(() -> Card.forSave(type, content, null, user))
-            .isInstanceOf(CardException.class)
-            .hasMessage(RETROSPECT_ROOM_IS_NOT_NULL.getMessage());
-    }
-
-    @DisplayName("Card의 User이 비어있음 예외가 발생한다.")
-    @Test
-    void nullUserTest() {
-        // given
-        // when
-        // then
-        assertThatThrownBy(() -> Card.forSave(type, content, retrospectRoom, null))
-            .isInstanceOf(CardException.class)
-            .hasMessage(USER_IS_NOT_NULL.getMessage());
     }
 
     @DisplayName("Card의 Type이 유효한 type(KEEP, PROBLEM, TRY)이 아니면 예외가 발생한다.")

--- a/src/test/java/choorai/retrospect/retrospect_room/card/entity/value/TypeTest.java
+++ b/src/test/java/choorai/retrospect/retrospect_room/card/entity/value/TypeTest.java
@@ -1,0 +1,21 @@
+package choorai.retrospect.retrospect_room.card.entity.value;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class TypeTest {
+
+    @DisplayName("유효한 type인지 검증할 수 있다.")
+    @CsvSource({"keep, true", "아,false", "TRY, true", "ProBlem, true", "ajflkds,false"})
+    @ParameterizedTest(name = "{0}의 Type 유효성 검증 결과는 {1}이다.")
+    void invalidTest(String typeValue, boolean expectedResult) {
+        // given
+        // when
+        final boolean result = Type.isValidType(typeValue);
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+    }
+}

--- a/src/test/java/choorai/retrospect/retrospect_room/card/entity/value/TypeTest.java
+++ b/src/test/java/choorai/retrospect/retrospect_room/card/entity/value/TypeTest.java
@@ -9,13 +9,13 @@ import org.junit.jupiter.params.provider.CsvSource;
 class TypeTest {
 
     @DisplayName("유효한 type인지 검증할 수 있다.")
-    @CsvSource({"keep, true", "아,false", "TRY, true", "ProBlem, true", "ajflkds,false"})
+    @CsvSource({"keep, KEEP", "PROBLEM, PROBLEM", "tRy, TRY"})
     @ParameterizedTest(name = "{0}의 Type 유효성 검증 결과는 {1}이다.")
-    void invalidTest(String typeValue, boolean expectedResult) {
+    void invalidTest(String typeValue, Type expectedType) {
         // given
         // when
-        final boolean result = Type.isValidType(typeValue);
+        final Type result = Type.fromString(typeValue);
         // then
-        assertThat(result).isEqualTo(expectedResult);
+        assertThat(result).isEqualTo(expectedType);
     }
 }

--- a/src/test/java/choorai/retrospect/user/entity/UserTest.java
+++ b/src/test/java/choorai/retrospect/user/entity/UserTest.java
@@ -3,6 +3,7 @@ package choorai.retrospect.user.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import choorai.retrospect.user.entity.value.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +40,8 @@ class UserTest {
         final String departmentInput = "부서이름";
         final String positionInput = "직급이름";
         // when
-        final User user = new User(emailInput, passwordInput, nameInput, companyInput, departmentInput, positionInput);
+        final User user = new User(emailInput, passwordInput, nameInput, companyInput, departmentInput, positionInput,
+                                   Role.USER);
         // then
         assertAll(
             () -> assertThat(user.getEmail().getValue())

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,8 +1,4 @@
 spring:
-  config:
-    activate:
-      on-profile: test
-
   datasource:
     url:  jdbc:h2:mem:test
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9075a8ac-ac3f-49a4-b10d-6e99f36e426f)

위 구조도에 맞게 entity를 생성하였습니다.

### 참고
말씀해주셨던대로, RetrospectRoom이나 User에서
```
    public void addCard(Card card) {
        card.setUser(this);
        this.cards.add(card);
    }
```
요렇게 구성하려 했으나,

Collections의 추가 및 삭제가 로직에 엄청난!! 영향을 미칠만큼 중요한 로직도 아닌데 굳이 Card내 필드에 대해 setter를 열어두는 것이 부담스러워서 .. 
일단 기존과 동일하게 구현해두었습니다.

의견있음 편히 말씀해주세요!
