### PR TITLE
RH-27 : auth 문서화 테스트 이동 및 이름 변경

### DIFF
--- a/src/test/java/choorai/retrospect/docs/AuthDocumentationTest.java
+++ b/src/test/java/choorai/retrospect/docs/AuthDocumentationTest.java
@@ -1,4 +1,4 @@
-package choorai.retrospect.auth.docs;
+package choorai.retrospect.docs;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -42,7 +42,7 @@ import org.springframework.web.context.WebApplicationContext;
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
-class AuthControllerTest {
+class AuthDocumentationTest {
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
- auth/docs에 있던 문서화 테스트를 docs 밑으로 옮김
- authControllerTest -> authDocumentationTest로 네이밍 변경