### PR TITLE
RH-29 :  api 문서 자동 배포 github Action workflow 추가

### DIFF
--- a/.github/workflows/api-docs-deploy.yml
+++ b/.github/workflows/api-docs-deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy APi Docs
+
+on:
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: api-docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Pages
+        uses: actions/configure-pages@v5
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "gradle"
+      - name: Build Asciidoc
+        run: ./gradlew asciidoctor
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./build/docs/asciidoc"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,4 +1,4 @@
-= Retrospect-room Api 문서
+= Auth Api 문서
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs

--- a/src/docs/asciidoc/card.adoc
+++ b/src/docs/asciidoc/card.adoc
@@ -1,0 +1,52 @@
+= Card Api 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+
+== 카드 생성하기
+
+=== Request
+include::{snippets}/card-create/request-fields.adoc[]
+include::{snippets}/card-create/http-request.adoc[]
+
+=== Response
+include::{snippets}/card-create/response-fields.adoc[]
+include::{snippets}/card-create/http-response.adoc[]
+
+== 단일 카드 조회하기
+
+=== Request
+include::{snippets}/card-get-by-id/http-request.adoc[]
+
+=== Response
+include::{snippets}/card-get-by-id/response-fields.adoc[]
+include::{snippets}/card-get-by-id/http-response.adoc[]
+
+== 모든 카드 조회하기
+=== Request
+include::{snippets}/card-get-all/http-request.adoc[]
+
+=== Response
+include::{snippets}/card-get-all/response-fields.adoc[]
+include::{snippets}/card-get-all/http-response.adoc[]
+
+== 카드 수정하기
+
+=== Request
+include::{snippets}/card-update/request-fields.adoc[]
+include::{snippets}/card-update/http-request.adoc[]
+
+=== Response
+include::{snippets}/card-update/response-fields.adoc[]
+include::{snippets}/card-update/http-response.adoc[]
+
+== 카드 삭제하기
+
+=== Request
+include::{snippets}/card-delete/http-request.adoc[]
+
+=== Response
+include::{snippets}/card-delete/response-fields.adoc[]
+include::{snippets}/card-delete/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,12 @@
+= Choorai API Docs
+
+== 설명
+```
+회고 서비스에 필요한 모든 API 문서입니다
+잘못된 부분이 있으면 개발자에게 문의해주세요.
+```
+
+== API Docs Link
+- link:https://choorai.github.io/retrospect-backend/auth.html[Auth Api docs]
+- link:https://choorai.github.io/retrospect-backend/retrospect-room.html[Retrospect Room Api docs]
+- link:https://choorai.github.io/retrospect-backend/card.html[Card Api docs]


### PR DESCRIPTION
jira : https://choorai.atlassian.net/jira/software/projects/RH/boards/1?selectedIssue=RH-29

## 진행사항
api 문서를 새로운 레포에 관리하고 netlify에 배포하는 것을 고려했으나 github page로도 무료로 배포할 수 있고 특정한 설정 없이도 https로 통신하기에 github page에 배포했습니다. 다만 항상 repository를 public하게 관리해야 한다는 점입니다. (private repo를 github page에 배포하려면 유료 버전을 이용해야 합니다.)


이번에 추가한 githubAction workflow
```yaml
name: Deploy APi Docs

on:
  push:
    branches:
      - develop

concurrency:
  group: github-pages
  cancel-in-progress: true

jobs:
  deploy:
    permissions:
      pages: write
      id-token: write
    environment:
      name: api-docs
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4
      - name: Set up Pages
        uses: actions/configure-pages@v5
      - name: Set up JDK 17
        uses: actions/setup-java@v4
        with:
          java-version: "17"
          distribution: "temurin"
          cache: "gradle"
      - name: Build Asciidoc
        run: ./gradlew asciidoctor
      - name: Upload pages artifact
        uses: actions/upload-pages-artifact@v3
        with:
          path: "./build/docs/asciidoc"
      - name: Deploy to GitHub Pages
        id: deployment
        uses: actions/deploy-pages@v4

``` 
### concurrency
- 동시에 해당 github action이 실행되는 경우 가장 뒤에 배포를 반영하는 것을 의미합니다.

### permissions
- github pages에 쓰기 권환을 부여하는 작업입니다.

### environment
- 실행 작업 환경의 이름을 의미하여 api docs를 배포하는 것이어서 이름을 api-docs로 구성했습니다.

